### PR TITLE
#169: 카카오톡 로그인 앱으로 안하는 이슈 수정

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.timber)
     implementation(libs.lottie)
+    implementation(libs.kakao.sdk)
 }

--- a/core/ui/src/main/kotlin/com/bff/wespot/util/KakaoLoginManager.kt
+++ b/core/ui/src/main/kotlin/com/bff/wespot/util/KakaoLoginManager.kt
@@ -19,7 +19,6 @@ class KakaoLoginManager {
         return try {
             when (loginState) {
                 KaKaoLoginState.KAKAO_TALK_LOGIN -> {
-
                     val token = UserApiClient.loginWithKakaoTalk(context)
                     KakaoAuthToken(
                         accessToken = token.accessToken,
@@ -55,7 +54,7 @@ class KakaoLoginManager {
     }
 
     private suspend fun UserApiClient.Companion.loginWithKakaoAccount(
-        context: Context
+        context: Context,
     ): OAuthToken {
         return suspendCancellableCoroutine { continuation ->
             instance.loginWithKakaoAccount(context) { token, error ->

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     implementation(libs.kotlin.serialization.json)
     implementation(libs.timber)
     implementation(libs.junit)
-    implementation(libs.kakao.sdk)
     implementation(libs.datastore)
     implementation(libs.paging3)
 }

--- a/data/src/main/kotlin/com/bff/wespot/data/di/DataModule.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/di/DataModule.kt
@@ -4,7 +4,6 @@ import com.bff.wespot.data.repository.CommonRepositoryImpl
 import com.bff.wespot.data.repository.DataStoreRepositoryImpl
 import com.bff.wespot.data.repository.RemoteConfigRepositoryImpl
 import com.bff.wespot.data.repository.auth.AuthRepositoryImpl
-import com.bff.wespot.data.repository.auth.KakaoLoginManagerImpl
 import com.bff.wespot.data.repository.message.MessageRepositoryImpl
 import com.bff.wespot.data.repository.message.MessageStorageRepositoryImpl
 import com.bff.wespot.data.repository.notification.NotificationRepositoryImpl
@@ -15,7 +14,6 @@ import com.bff.wespot.domain.repository.CommonRepository
 import com.bff.wespot.domain.repository.DataStoreRepository
 import com.bff.wespot.domain.repository.RemoteConfigRepository
 import com.bff.wespot.domain.repository.auth.AuthRepository
-import com.bff.wespot.domain.repository.auth.KakaoLoginManager
 import com.bff.wespot.domain.repository.message.MessageRepository
 import com.bff.wespot.domain.repository.message.MessageStorageRepository
 import com.bff.wespot.domain.repository.notification.NotificationRepository
@@ -36,12 +34,6 @@ abstract class DataModule {
     abstract fun bindsMessageRepository(
         messageRepository: MessageRepositoryImpl
     ): MessageRepository
-
-    @Binds
-    @Singleton
-    abstract fun bindsKakaoLoginManager(
-        kakaoLoginManagerImpl: KakaoLoginManagerImpl
-    ): KakaoLoginManager
 
     @Binds
     @Singleton

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/auth/KakaoLoginManager.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/auth/KakaoLoginManager.kt
@@ -1,7 +1,0 @@
-package com.bff.wespot.domain.repository.auth
-
-import com.bff.wespot.model.auth.request.KakaoAuthToken
-
-interface KakaoLoginManager {
-    suspend fun loginWithKakao(): KakaoAuthToken
-}

--- a/domain/src/main/kotlin/com/bff/wespot/domain/usecase/KakaoLoginUseCase.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/usecase/KakaoLoginUseCase.kt
@@ -2,20 +2,18 @@ package com.bff.wespot.domain.usecase
 
 import com.bff.wespot.domain.repository.DataStoreRepository
 import com.bff.wespot.domain.repository.auth.AuthRepository
-import com.bff.wespot.domain.repository.auth.KakaoLoginManager
 import com.bff.wespot.domain.util.DataStoreKey
+import com.bff.wespot.model.auth.request.KakaoAuthToken
 import com.bff.wespot.model.auth.response.AuthToken
 import com.bff.wespot.model.auth.response.SignUpToken
 import com.bff.wespot.model.constants.LoginState
 import javax.inject.Inject
 
 class KakaoLoginUseCase @Inject constructor(
-    private val kakaoLoginManager: KakaoLoginManager,
     private val authRepository: AuthRepository,
     private val dataStoreRepository: DataStoreRepository,
 ) {
-    suspend operator fun invoke(): Result<LoginState> {
-        val result = kakaoLoginManager.loginWithKakao()
+    suspend operator fun invoke(result: KakaoAuthToken): Result<LoginState> {
         return authRepository.sendKakaoToken(result)
             .map {
                 when (it) {

--- a/feature/auth/src/main/kotlin/com/bff/wespot/auth/screen/AuthScreen.kt
+++ b/feature/auth/src/main/kotlin/com/bff/wespot/auth/screen/AuthScreen.kt
@@ -22,10 +22,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -41,8 +43,10 @@ import com.bff.wespot.auth.viewmodel.AuthViewModel
 import com.bff.wespot.designsystem.theme.StaticTypeScale
 import com.bff.wespot.ui.DotIndicators
 import com.bff.wespot.ui.WSCarousel
+import com.bff.wespot.util.KakaoLoginManager
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Destination
@@ -52,6 +56,10 @@ fun AuthScreen(
     viewModel: AuthViewModel,
 ) {
     val pagerState = rememberPagerState { 3 }
+    val kakaoLogin = KakaoLoginManager()
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -105,7 +113,10 @@ fun AuthScreen(
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
         Button(
             onClick = {
-                viewModel.onAction(AuthAction.LoginWithKakao)
+                coroutineScope.launch {
+                    val token = kakaoLogin.loginWithKakao(context)
+                    viewModel.onAction(AuthAction.LoginWithKakao(token))
+                }
             },
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/auth/src/main/kotlin/com/bff/wespot/auth/state/AuthAction.kt
+++ b/feature/auth/src/main/kotlin/com/bff/wespot/auth/state/AuthAction.kt
@@ -1,5 +1,6 @@
 package com.bff.wespot.auth.state
 
+import com.bff.wespot.model.auth.request.KakaoAuthToken
 import com.bff.wespot.model.auth.response.School
 
 sealed class AuthAction {
@@ -17,7 +18,7 @@ sealed class AuthAction {
 
     data class OnNameChanged(val name: String) : AuthAction()
 
-    data object LoginWithKakao : AuthAction()
+    data class LoginWithKakao(val token: KakaoAuthToken) : AuthAction()
 
     data object Signup : AuthAction()
 

--- a/feature/auth/src/main/kotlin/com/bff/wespot/auth/viewmodel/AuthViewModel.kt
+++ b/feature/auth/src/main/kotlin/com/bff/wespot/auth/viewmodel/AuthViewModel.kt
@@ -15,6 +15,7 @@ import com.bff.wespot.domain.usecase.AutoLoginUseCase
 import com.bff.wespot.domain.usecase.CheckProfanityUseCase
 import com.bff.wespot.domain.usecase.KakaoLoginUseCase
 import com.bff.wespot.domain.util.RemoteConfigKey
+import com.bff.wespot.model.auth.request.KakaoAuthToken
 import com.bff.wespot.model.auth.request.SignUp
 import com.bff.wespot.model.auth.response.Consents
 import com.bff.wespot.model.auth.response.School
@@ -72,7 +73,7 @@ class AuthViewModel @Inject constructor(
             is AuthAction.OnGenderChanged -> handleGenderChanged(action.gender)
             is AuthAction.OnNameChanged -> handleNameChanged(action.name)
             is AuthAction.Navigation -> handleNavigation(action.navigate)
-            is AuthAction.LoginWithKakao -> loginWithKakao()
+            is AuthAction.LoginWithKakao -> loginWithKakao(action.token)
             is AuthAction.Signup -> signUp()
             is AuthAction.AutoLogin -> autoLogin(action.versionCode)
             is AuthAction.OnStartSchoolScreen -> monitorUserInput()
@@ -81,10 +82,10 @@ class AuthViewModel @Inject constructor(
         }
     }
 
-    private fun loginWithKakao() = intent {
+    private fun loginWithKakao(kakaoAuthToken: KakaoAuthToken) = intent {
         viewModelScope.launch {
             try {
-                kakaoLoginUseCase()
+                kakaoLoginUseCase(kakaoAuthToken)
                     .onSuccess {
                         if (it == LoginState.LOGIN_SUCCESS) {
                             postSideEffect(AuthSideEffect.NavigateToMainActivity)


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
close #169 

## 2. 🔥 변경된 점
KakaoLoginManager를 data쪽에서 처리해서 ApplicationContext를 주입했는데 이런 이슈가 발생하고 있어서 앱으로 로그인을 못하고 있던 상황
https://devtalk.kakao.com/t/flag-activity-new-task/111688

## 3. ✅ 필수 체크 사항 
카카오톡 앱으로 로그인 되는지, 현재 제 계정은 모든 권한을 등록한 상태라 바로 로그인 되는데 실제로는 권한 받는 다는 메시지가 뜨는지

## 4. 📸 작업물 사진 공유(선택)
| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/37e6305b-8220-4e11-8a33-d6d584ae468f" width="350" />| <video src="https://github.com/user-attachments/assets/400cd73c-2f64-4913-9460-0e0966bfbc0b" width="350" /> |

## 5. 💡알게된 혹은 궁금한 사항
