### PR TITLE
#182 : 쪽지 진입시 시간대에 맞는 로띠 노출되도록 수정해요

### DIFF
--- a/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/MessageViewModel.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/MessageViewModel.kt
@@ -42,7 +42,11 @@ class MessageViewModel @Inject constructor(
             messageReceiveTime = remoteConfigRepository.fetchFromRemoteConfig(
                 RemoteConfigKey.MESSAGE_RECEIVE_TIME,
             ),
-        ),
+        ).let { state ->
+            state.copy(
+                timePeriod = getCurrentTimePeriod(state.messageStartTime, state.messageReceiveTime),
+            )
+        },
     )
 
     private val _remainingTimeMillis: MutableStateFlow<Long> = MutableStateFlow(0)


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#182 쪽지 진입시, 시간대에 맞는 로띠 노출되도록 수정해요.

## 2. 🔥 변경된 점

기존 디폴트 로띠 후 시간대 로띠가 보였었는데, 해당 부분 어색해서 수정했습니닷 

## 3. ✅ 필수 체크 사항 

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡알게된 혹은 궁금한 사항
