### PR TITLE
#184 : 타이머 시작시, 쪽지 상태 불러오는 코드 추가해요

### DIFF
--- a/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/MessageViewModel.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/MessageViewModel.kt
@@ -101,6 +101,7 @@ class MessageViewModel @Inject constructor(
 
     private fun startTimer() = intent {
         if (!timerJob.isActive) {
+            setTimer()
             timerJob.start()
         }
     }
@@ -130,22 +131,20 @@ class MessageViewModel @Inject constructor(
         }
     }
 
-    /**
-     * TimePeriod Default 값은 DAWN_TO_EVENING으로
-     * DAWN_TO_EVENING 상태에서 다른 행동을 수행하지 않기 때문에, TimePeriod가 변경되었을 때만 행동을 수행한다.
-     */
     private fun updateTimePeriod(currentTimePeriod: TimePeriod) = intent {
         if (state.timePeriod != currentTimePeriod) {
-            getMessageStatus()
-
-            // 메세지 전송 가능한 시간이 경우, 타이머 시각을 설정한다.
-            if (currentTimePeriod == TimePeriod.EVENING_TO_NIGHT) {
-                _remainingTimeMillis.value = getRemainingTimeMillis()
-            }
-
             reduce {
                 state.copy(timePeriod = currentTimePeriod)
             }
+            setTimer()
+        }
+    }
+
+    private fun setTimer() = intent {
+        getMessageStatus()
+
+        if (state.timePeriod == TimePeriod.EVENING_TO_NIGHT) {
+            _remainingTimeMillis.value = getRemainingTimeMillis()
         }
     }
 


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#184 쪽지 진입시 쪽지 상태 로드하도록 수정해요

## 2. 🔥 변경된 점

쪽지 진입 시, 상태를 불러오는 코드를 추가했어요 

## 3. ✅ 필수 체크 사항 

상용버전 이슈 X

쪽지 시간대 미리 불러오는 로직 추가로 발생한 버그입니다. 

기존 쪽지 상태를 불러오는 로직이, 쪽지 시간대가 변경될 때 불러오고 있었는데, 

미리 쪽지 시간대를 불러와서 해당 로직이 수행되지 않는 버그가 발생했어요 .

해당 이슈 관련한 영상 첨부드립니다 ! 땡큐 매튜 


https://github.com/user-attachments/assets/b729035d-eafa-49ba-a7d2-aa300bd7351d



## 4. 📸 작업물 사진 공유(선택)

현재는 정상적으로 쪽지가 동작하도록 바뀌었어요 

<img width="327" alt="image" src="https://github.com/user-attachments/assets/00d094f4-31de-469b-ae4e-3117e106f4fe">

#7번으로 테스트 앱 확인할 수 있습니다 !

## 5. 💡알게된 혹은 궁금한 사항
