### PR TITLE
#181: 카카오톡 로그인 뒤로갈시 튕기는 버그 수정

### DIFF
--- a/core/ui/src/main/kotlin/com/bff/wespot/ui/util/KakaoLoginManager.kt
+++ b/core/ui/src/main/kotlin/com/bff/wespot/ui/util/KakaoLoginManager.kt
@@ -90,7 +90,6 @@ class KakaoLoginManager {
                 Timber.d("로그아웃 성공. SDK에서 토큰 삭제됨")
             }
         }
-
     }
 }
 
@@ -98,4 +97,3 @@ enum class KaKaoLoginState {
     KAKAO_TALK_LOGIN,
     KAKAO_ACCOUNT_LOGIN,
 }
-

--- a/core/ui/src/main/kotlin/com/bff/wespot/ui/util/KakaoLoginManager.kt
+++ b/core/ui/src/main/kotlin/com/bff/wespot/ui/util/KakaoLoginManager.kt
@@ -47,7 +47,6 @@ class KakaoLoginManager {
     private suspend fun UserApiClient.Companion.loginWithKakaoTalk(context: Context): OAuthToken {
         return suspendCancellableCoroutine { continuation ->
             instance.loginWithKakaoTalk(context) { token, error ->
-                Timber.d("loginWithKakaoTalk token: $token, error: $error")
                 continuation.resumeTokenOrException(token, error)
             }
         }
@@ -82,9 +81,21 @@ class KakaoLoginManager {
             resumeWithException(RuntimeException("Failed to get kakao access token, reason is not clear."))
         }
     }
+
+    companion object {
+        fun logout() = UserApiClient.instance.logout { error ->
+            if (error != null) {
+                Timber.d("로그아웃 실패. SDK에서 토큰 삭제됨")
+            } else {
+                Timber.d("로그아웃 성공. SDK에서 토큰 삭제됨")
+            }
+        }
+
+    }
 }
 
 enum class KaKaoLoginState {
     KAKAO_TALK_LOGIN,
     KAKAO_ACCOUNT_LOGIN,
 }
+

--- a/feature/auth/src/main/kotlin/com/bff/wespot/auth/screen/AuthScreen.kt
+++ b/feature/auth/src/main/kotlin/com/bff/wespot/auth/screen/AuthScreen.kt
@@ -117,8 +117,10 @@ fun AuthScreen(
         Button(
             onClick = {
                 coroutineScope.launch {
-                    val token = kakaoLogin.loginWithKakao(context)
-                    viewModel.onAction(AuthAction.LoginWithKakao(token))
+                    runCatching {
+                        val token = kakaoLogin.loginWithKakao(context)
+                        viewModel.onAction(AuthAction.LoginWithKakao(token))
+                    }
                 }
             },
             modifier = Modifier

--- a/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
@@ -17,6 +17,7 @@ import com.bff.wespot.model.common.Paging
 import com.bff.wespot.model.message.response.BlockedMessage
 import com.bff.wespot.ui.base.BaseViewModel
 import com.bff.wespot.ui.model.SideEffect.Companion.toSideEffect
+import com.bff.wespot.ui.util.KakaoLoginManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -110,6 +111,7 @@ class EntireViewModel @Inject constructor(
 
     private fun signOut() = intent {
         clearCachedData()
+        KakaoLoginManager.logout()
         postSideEffect(EntireSideEffect.NavigateToAuth)
     }
 


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
close #181 

## 2. 🔥 변경된 점
카카오톡 뒤로갈시 터지는 버그가 있었는데 수정
https://console.firebase.google.com/project/wespot-20f89/crashlytics/app/android:com.bff.wespot.real/issues/4a8620288708347277be5e9476cfa148?hl=ko&time=last-ninety-days&types=crash&sessionEventKey=6704692E0248000141788A3065BA4322_2001619622171465168

## 3. ✅ 필수 체크 사항 

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡알게된 혹은 궁금한 사항
