### PR TITLE
#204 : 예약된 쪽지 수정화면 수정해요

### DIFF
--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageEditScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageEditScreen.kt
@@ -117,7 +117,8 @@ fun MessageEditScreen(
         topBar = {
             WSTopBar(
                 title = "",
-                canNavigateBack = true,
+                // 예약된 쪽지인 경우, action 버튼과 중복되는 동작을 수행하여, 뒤로가기 버튼은 숨김 처리한다.
+                canNavigateBack = state.isReservedMessage.not(),
                 navigateUp = {
                     navigator.navigateUp()
                 },

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/send/SendAction.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/send/SendAction.kt
@@ -10,7 +10,6 @@ sealed class SendAction {
     data class OnMessageEditScreenEntered(val isReservedMessage: Boolean, val messageId: Int) : SendAction()
     data class OnEditButtonClicked(val messageId: Int) : SendAction()
     data object OnSendButtonClicked : SendAction()
-    data object OnInviteFriendTextClicked : SendAction()
     data object OnReceiverScreenEntered : SendAction()
     data object OnWriteScreenEntered : SendAction()
     data object OnReservedMessageScreenEntered : SendAction()

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/SendViewModel.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/SendViewModel.kt
@@ -69,7 +69,6 @@ class SendViewModel @Inject constructor(
             is SendAction.OnSendButtonClicked -> handleMessageSent()
             is SendAction.OnRandomNameToggled -> handleRandomNameToggled()
             is SendAction.OnEditButtonClicked -> handleEditButtonClicked(action.messageId)
-            SendAction.OnInviteFriendTextClicked -> {}
             SendAction.OnReservedMessageScreenEntered, SendAction.OnMessageScreenEntered -> {
                 clearSendUiState()
             }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

closed #204

#204 : 예약된 쪽지 수정화면 수정해요 
- [ [ 수정 제안 스레드 ](https://discord.com/channels/1241364675657203742/1241739388975714458/1308411988828880917) ]

## 2. 🔥 변경된 점

예약된 쪽지 화면에서 뒤로가기 버튼이 삭제되었습니다.

action 버튼이랑 동일한 동작을 수행하기 때문인 것 같아요 

추가로 미사용중인 action도 소거했어요 

## 3. ✅ 필수 체크 사항 


## 4. 📸 작업물 사진 공유(선택)

<img width="375" alt="image" src="https://github.com/user-attachments/assets/ed4b43f0-a597-4763-a03e-7afba4be9801">

## 5. 💡알게된 혹은 궁금한 사항

