### PR TITLE
#211 : 업데이트 유도 모달 추가해요

### DIFF
--- a/app/src/main/kotlin/com/bff/wespot/MainActivity.kt
+++ b/app/src/main/kotlin/com/bff/wespot/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.bff.wespot
 
 import android.Manifest
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
@@ -75,7 +76,10 @@ import com.bff.wespot.notification.screen.NotificationNavigator
 import com.bff.wespot.state.MainAction
 import com.bff.wespot.state.MainUiState
 import com.bff.wespot.data.remote.extensions.toLocalDateFromDashPattern
+import com.bff.wespot.designsystem.component.modal.WSDialog
+import com.bff.wespot.model.VersionUpdateDialogState
 import com.bff.wespot.navigation.util.EXTRA_DATE
+import com.bff.wespot.state.MainSideEffect
 import com.bff.wespot.ui.component.TopToast
 import com.bff.wespot.ui.component.WSBottomSheet
 import com.bff.wespot.ui.model.ToastState
@@ -87,6 +91,7 @@ import com.ramcosta.composedestinations.spec.NavGraphSpec
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 import timber.log.Timber
 import java.time.LocalDate
 import javax.inject.Inject
@@ -186,10 +191,23 @@ private fun MainScreen(
     val action = viewModel::onAction
 
     val navController = rememberNavController()
+    val context = LocalContext.current
     var toast by remember { mutableStateOf(ToastState()) }
+    var showVersionUpdateDialog by remember { mutableStateOf(VersionUpdateDialogState()) }
 
     val isTopNavigationScreen by navController.checkCurrentScreen(NavigationBarPosition.TOP)
     val isBottomNavigationScreen by navController.checkCurrentScreen(NavigationBarPosition.BOTTOM)
+
+    viewModel.collectSideEffect {
+        when (it) {
+            is MainSideEffect.ShowVersionUpdateDialog -> {
+                showVersionUpdateDialog = VersionUpdateDialogState(
+                    show = true,
+                    versionUpdateType = it.versionUpdateType,
+                )
+            }
+        }
+    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -303,6 +321,22 @@ private fun MainScreen(
         toast = toast.copy(show = false)
     }
 
+    if (showVersionUpdateDialog.show) {
+        WSDialog(
+            title = showVersionUpdateDialog.versionUpdateType.title,
+            subTitle = showVersionUpdateDialog.versionUpdateType.subTitle,
+            okButtonText = stringResource(string.update),
+            cancelButtonText = stringResource(string.next_time_update),
+            okButtonClick = {
+                navigator.navigateToWebLink(context, state.playStoreLink)
+            },
+            cancelButtonClick = {
+                showVersionUpdateDialog = showVersionUpdateDialog.copy(show = false)
+            },
+            onDismissRequest = {},
+        )
+    }
+
     if (state.restriction.restrictionType != RestrictionType.NONE) {
         RestrictionBottomSheet(
             content = when (state.restriction.restrictionType) {
@@ -317,7 +351,7 @@ private fun MainScreen(
     }
 
     LaunchedEffect(Unit) {
-        action(MainAction.OnMainScreenEntered)
+        action(MainAction.OnMainScreenEntered(context.getAppVersionName()))
     }
 }
 
@@ -630,3 +664,6 @@ private enum class RestrictionContent(
         2,
     );
 }
+
+private fun Context.getAppVersionName(): String =
+    this.packageManager.getPackageInfo(this.packageName, 0).versionName

--- a/app/src/main/kotlin/com/bff/wespot/model/VersionUpdateDialogState.kt
+++ b/app/src/main/kotlin/com/bff/wespot/model/VersionUpdateDialogState.kt
@@ -1,0 +1,46 @@
+package com.bff.wespot.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.stringResource
+import com.bff.wespot.R
+
+data class VersionUpdateDialogState(
+    val show: Boolean = false,
+    val versionUpdateType: VersionUpdateType = VersionUpdateType.USABILITY_IMPROVEMENT,
+)
+
+/**
+ * @property [USABILITY_IMPROVEMENT] 사용성 개선
+ * @property [NEW_FEATURE_ADDED] 새로운 기능 추가
+ */
+enum class VersionUpdateType {
+    USABILITY_IMPROVEMENT,
+    NEW_FEATURE_ADDED,
+    ;
+
+    val title: String
+        @Composable
+        @ReadOnlyComposable
+        get() = when(this) {
+            USABILITY_IMPROVEMENT -> stringResource(id = R.string.update_title_usability_improvement)
+            NEW_FEATURE_ADDED -> stringResource(id = R.string.update_title_new_feature_added)
+        }
+
+    val subTitle: String
+        @Composable
+        @ReadOnlyComposable
+        get() = when(this) {
+            USABILITY_IMPROVEMENT -> stringResource(id = R.string.update_subtitle_usability_improvement)
+            NEW_FEATURE_ADDED -> stringResource(id = R.string.update_subtitle_new_feature_added)
+        }
+
+    companion object {
+        fun convertVersionUpdateType(versionUpdateTypeString: String) =
+            when (versionUpdateTypeString) {
+                USABILITY_IMPROVEMENT.name -> USABILITY_IMPROVEMENT
+                NEW_FEATURE_ADDED.name -> NEW_FEATURE_ADDED
+                else -> USABILITY_IMPROVEMENT
+            }
+    }
+}

--- a/app/src/main/kotlin/com/bff/wespot/state/MainAction.kt
+++ b/app/src/main/kotlin/com/bff/wespot/state/MainAction.kt
@@ -3,8 +3,8 @@ package com.bff.wespot.state
 import com.bff.wespot.MainScreenNavArgs
 
 sealed class MainAction {
-    data object OnMainScreenEntered : MainAction()
     data object OnNavigateByPushNotification : MainAction()
+    data class OnMainScreenEntered(val appVersionName: String) : MainAction()
     data class OnEnteredByPushNotification(val data: MainScreenNavArgs) : MainAction()
     data class OnNotificationSet(val isEnableNotification: Boolean) : MainAction()
 }

--- a/app/src/main/kotlin/com/bff/wespot/state/MainSideEffect.kt
+++ b/app/src/main/kotlin/com/bff/wespot/state/MainSideEffect.kt
@@ -1,3 +1,7 @@
 package com.bff.wespot.state
 
-sealed class MainSideEffect
+import com.bff.wespot.model.VersionUpdateType
+
+sealed interface MainSideEffect {
+    data class ShowVersionUpdateDialog(val versionUpdateType: VersionUpdateType): MainSideEffect
+}

--- a/app/src/main/kotlin/com/bff/wespot/state/MainUiState.kt
+++ b/app/src/main/kotlin/com/bff/wespot/state/MainUiState.kt
@@ -7,4 +7,5 @@ data class MainUiState (
     val userId: String = "",
     val restriction: Restriction = Restriction.Empty,
     val kakaoChannel: String,
+    val playStoreLink: String,
 )

--- a/app/src/main/kotlin/com/bff/wespot/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/com/bff/wespot/viewmodel/MainViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.bff.wespot.MainScreenNavArgs
 import com.bff.wespot.analytic.AnalyticsEvent
 import com.bff.wespot.analytic.AnalyticsHelper
+import com.bff.wespot.common.util.AppVersionUtils.VersionCompareResult
+import com.bff.wespot.common.util.AppVersionUtils.versionCompare
 import com.bff.wespot.domain.repository.CommonRepository
 import com.bff.wespot.domain.repository.DataStoreRepository
 import com.bff.wespot.domain.repository.firebase.config.RemoteConfigRepository
@@ -12,14 +14,17 @@ import com.bff.wespot.domain.repository.user.UserRepository
 import com.bff.wespot.domain.usecase.CacheProfileUseCase
 import com.bff.wespot.domain.util.DataStoreKey
 import com.bff.wespot.domain.util.RemoteConfigKey
+import com.bff.wespot.model.VersionUpdateType
 import com.bff.wespot.state.MainAction
 import com.bff.wespot.state.MainSideEffect
 import com.bff.wespot.state.MainUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 import timber.log.Timber
@@ -35,9 +40,16 @@ class MainViewModel @Inject constructor(
     private val commonRepository: CommonRepository,
     private val remoteConfigRepository: RemoteConfigRepository,
 ) : ViewModel(), ContainerHost<MainUiState, MainSideEffect> {
-    override val container = container<MainUiState, MainSideEffect>(MainUiState(
-        kakaoChannel = remoteConfigRepository.fetchFromRemoteConfig(RemoteConfigKey.WESPOT_KAKAO_CHANNEL_URL)
-    ))
+    override val container = container<MainUiState, MainSideEffect>(
+        MainUiState(
+            kakaoChannel = remoteConfigRepository.fetchFromRemoteConfig(
+                RemoteConfigKey.WESPOT_KAKAO_CHANNEL_URL,
+            ),
+            playStoreLink = remoteConfigRepository.fetchFromRemoteConfig(
+                RemoteConfigKey.PLAY_STORE_URL,
+            ),
+        )
+    )
 
     init {
         viewModelScope.launch {
@@ -55,8 +67,8 @@ class MainViewModel @Inject constructor(
 
     fun onAction(action: MainAction) {
         when (action) {
-            MainAction.OnMainScreenEntered -> handleMainScreenEntered()
             MainAction.OnNavigateByPushNotification -> handleNavigateByPushNotification()
+            is MainAction.OnMainScreenEntered -> handleMainScreenEntered(action.appVersionName)
             is MainAction.OnEnteredByPushNotification -> {
                 handleEnteredByPushNotification()
                 trackPushNotificationClicked(action.data)
@@ -65,9 +77,14 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    private fun handleMainScreenEntered() = intent {
+    private fun handleMainScreenEntered(appVersion: String) = intent {
         viewModelScope.launch(coroutineDispatcher) {
             cacheProfileUseCase()
+
+            if (isAppVersionMatchCachedVersion(appVersion).not()) {
+                checkAppVersionWithLatestVersion(appVersion)
+            }
+
             commonRepository.getRestriction()
                 .onSuccess {
                     reduce {
@@ -75,6 +92,39 @@ class MainViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    /** 마지막으로 버전 검사를 진행한 버전 정보를 불러와 현재 앱 버전과 대조한다. */
+    private suspend fun isAppVersionMatchCachedVersion(appVersion: String): Boolean {
+        val versionLastChecked = dataStoreRepository
+            .getString(DataStoreKey.VERSION_LAST_CHECKED)
+            .first()
+
+        return appVersion == versionLastChecked
+    }
+
+    /** 최신 버전을 불러와 현재 버전과 비교하며, 현재 앱 정보를 마지막 버전 검사 버전으로 저장한다. */
+    private suspend fun checkAppVersionWithLatestVersion(appVersion: String) = intent {
+        val latestVersion = remoteConfigRepository.fetchFromRemoteConfig(RemoteConfigKey.LATEST_VERSION)
+
+        val result = versionCompare(appVersion = appVersion, compareVersion = latestVersion)
+        when (result) {
+            VersionCompareResult.MAJOR_VERSION_UPDATE -> {
+                postSideEffect(MainSideEffect.ShowVersionUpdateDialog(VersionUpdateType.NEW_FEATURE_ADDED))
+            }
+
+            VersionCompareResult.MINOR_VERSION_UPDATE -> {
+                val versionUpdateTypeString = remoteConfigRepository
+                    .fetchFromRemoteConfig(RemoteConfigKey.VERSION_UPDATE_TYPE)
+                val versionUpdateType = VersionUpdateType.convertVersionUpdateType(versionUpdateTypeString)
+                postSideEffect(MainSideEffect.ShowVersionUpdateDialog(versionUpdateType))
+            }
+
+            VersionCompareResult.LATEST_VERSION, VersionCompareResult.PATCH_VERSION_UPDATE -> {
+            }
+        }
+
+        dataStoreRepository.saveString(DataStoreKey.VERSION_LAST_CHECKED, appVersion)
     }
 
     private fun handleNotificationSet(isEnableNotification: Boolean) = intent {

--- a/app/src/main/kotlin/com/bff/wespot/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/com/bff/wespot/viewmodel/MainViewModel.kt
@@ -20,7 +20,7 @@ import com.bff.wespot.state.MainSideEffect
 import com.bff.wespot.state.MainUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -81,9 +81,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch(coroutineDispatcher) {
             cacheProfileUseCase()
 
-            if (isAppVersionMatchCachedVersion(appVersion).not()) {
-                checkAppVersionWithLatestVersion(appVersion)
-            }
+            checkAppVersionWithLatestVersion(appVersion)
 
             commonRepository.getRestriction()
                 .onSuccess {
@@ -94,37 +92,51 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    /** 마지막으로 버전 검사를 진행한 버전 정보를 불러와 현재 앱 버전과 대조한다. */
-    private suspend fun isAppVersionMatchCachedVersion(appVersion: String): Boolean {
-        val versionLastChecked = dataStoreRepository
-            .getString(DataStoreKey.VERSION_LAST_CHECKED)
-            .first()
-
-        return appVersion == versionLastChecked
-    }
-
-    /** 최신 버전을 불러와 현재 버전과 비교하며, 현재 앱 정보를 마지막 버전 검사 버전으로 저장한다. */
+    /** RemoteConfig에서 최신 버전을 가져와 현재 앱 버전과 비교하고 적절한 업데이트 다이얼로그를 노출한다.*/
     private suspend fun checkAppVersionWithLatestVersion(appVersion: String) = intent {
         val latestVersion = remoteConfigRepository.fetchFromRemoteConfig(RemoteConfigKey.LATEST_VERSION)
 
         val result = versionCompare(appVersion = appVersion, compareVersion = latestVersion)
         when (result) {
             VersionCompareResult.MAJOR_VERSION_UPDATE -> {
-                postSideEffect(MainSideEffect.ShowVersionUpdateDialog(VersionUpdateType.NEW_FEATURE_ADDED))
+                if (isVersionMatchCachedVersion(latestVersion).not()) {
+                    postSideEffect(
+                        MainSideEffect.ShowVersionUpdateDialog(VersionUpdateType.NEW_FEATURE_ADDED)
+                    )
+                }
             }
 
             VersionCompareResult.MINOR_VERSION_UPDATE -> {
-                val versionUpdateTypeString = remoteConfigRepository
-                    .fetchFromRemoteConfig(RemoteConfigKey.VERSION_UPDATE_TYPE)
-                val versionUpdateType = VersionUpdateType.convertVersionUpdateType(versionUpdateTypeString)
-                postSideEffect(MainSideEffect.ShowVersionUpdateDialog(versionUpdateType))
+                if (isVersionMatchCachedVersion(latestVersion).not()) {
+                    /** 마이너 버전 업데이트의 경우 업데이트 타입에 따라 다이얼로그를 구분한다. */
+                    val versionUpdateTypeString = remoteConfigRepository
+                        .fetchFromRemoteConfig(RemoteConfigKey.VERSION_UPDATE_TYPE)
+                    val versionUpdateType = VersionUpdateType.convertVersionUpdateType(versionUpdateTypeString)
+
+                    postSideEffect(MainSideEffect.ShowVersionUpdateDialog(versionUpdateType))
+                }
             }
 
             VersionCompareResult.LATEST_VERSION, VersionCompareResult.PATCH_VERSION_UPDATE -> {
             }
         }
+    }
 
-        dataStoreRepository.saveString(DataStoreKey.VERSION_LAST_CHECKED, appVersion)
+    /**
+     * 캐시된 버전 정보를 확인하여 이전에 비교한 경험이 있는지 확인한다.
+     * 만약 새로운 최신 버전이라면 캐시에 저장하고 false를 반환한다.
+     */
+    private suspend fun isVersionMatchCachedVersion(version: String): Boolean {
+        val versionLastChecked = dataStoreRepository
+            .getString(DataStoreKey.VERSION_LAST_CHECKED)
+            .firstOrNull()
+
+        if (version != versionLastChecked) {
+            dataStoreRepository.saveString(DataStoreKey.VERSION_LAST_CHECKED, version)
+            return false
+        } else {
+            return true
+        }
     }
 
     private fun handleNotificationSet(isEnableNotification: Boolean) = intent {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,10 @@
     <string name="restriction_type3_body2">[이용 제한 기한]\n학교·학년·반 정보 오기입</string>
     <string name="restriction_type3_body3">이용 제한은 \'1:1 문의하기\'를 통한 개인 정보 수정 이후 해제됩니다</string>
     <string name="one_on_one">1:1 문의하기</string>
+    <string name="update">업데이트</string>
+    <string name="next_time_update">다음에 할래요</string>
+    <string name="update_title_usability_improvement">새로운 버전이 업데이트 되었어요!</string>
+    <string name="update_title_new_feature_added">새로운 버전이 업데이트 되었어요!</string>
+    <string name="update_subtitle_usability_improvement">유저의 의견을 반영해서 사용성을 개선했어요\n지금 업데이트하고 더 나은 위스팟을 만나보세요</string>
+    <string name="update_subtitle_new_feature_added">유저의 의견을 반영하여 신규 기능을 출시했어요\n지금 업데이트하고 새로운 위스팟을 만나보세요</string>
 </resources>

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -2,6 +2,11 @@ plugins {
     alias(libs.plugins.wespot.jvm.library)
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation(project(":core:model"))
+    testImplementation(libs.junit.jupitor)
 }

--- a/core/common/src/main/kotlin/com/bff/wespot/common/util/AppVersionUtils.kt
+++ b/core/common/src/main/kotlin/com/bff/wespot/common/util/AppVersionUtils.kt
@@ -8,7 +8,8 @@ object AppVersionUtils {
         val maxLength = maxOf(compareVersionSplit.size, appVersionSplit.size)
 
         // 패치 버전이 빠지는 경우를 대비하여, 빈 버전은 0으로 채운다.
-        val extendedCompareVersion = compareVersionSplit + List(maxLength - compareVersionSplit.size) { 0 }
+        val extendedCompareVersion =
+            compareVersionSplit + List(maxLength - compareVersionSplit.size) { 0 }
         val extendedAppVersion = appVersionSplit + List(maxLength - appVersionSplit.size) { 0 }
 
         for (i in 0 until maxLength) {

--- a/core/common/src/main/kotlin/com/bff/wespot/common/util/AppVersionUtils.kt
+++ b/core/common/src/main/kotlin/com/bff/wespot/common/util/AppVersionUtils.kt
@@ -1,0 +1,45 @@
+package com.bff.wespot.common.util
+
+object AppVersionUtils {
+    fun versionCompare(appVersion: String, compareVersion: String): VersionCompareResult {
+        val compareVersionSplit = compareVersion.split(".").map { it.toIntOrNull() ?: 0 }
+        val appVersionSplit = appVersion.split(".").map { it.toIntOrNull() ?: 0 }
+
+        val maxLength = maxOf(compareVersionSplit.size, appVersionSplit.size)
+
+        // 패치 버전이 빠지는 경우를 대비하여, 빈 버전은 0으로 채운다.
+        val extendedCompareVersion = compareVersionSplit + List(maxLength - compareVersionSplit.size) { 0 }
+        val extendedAppVersion = appVersionSplit + List(maxLength - appVersionSplit.size) { 0 }
+
+        for (i in 0 until maxLength) {
+            when {
+                extendedAppVersion[i] < extendedCompareVersion[i] -> {
+                    return when (i) {
+                        0 -> VersionCompareResult.MAJOR_VERSION_UPDATE
+                        1 -> VersionCompareResult.MINOR_VERSION_UPDATE
+                        2 -> VersionCompareResult.PATCH_VERSION_UPDATE
+                        else -> VersionCompareResult.LATEST_VERSION
+                    }
+                }
+                extendedAppVersion[i] > extendedCompareVersion[i] -> {
+                    return VersionCompareResult.LATEST_VERSION
+                }
+            }
+        }
+
+        return VersionCompareResult.LATEST_VERSION
+    }
+
+    /**
+     * @property [MAJOR_VERSION_UPDATE] 현재 버전이 최신 버전의 메이저 버전이 낮음.
+     * @property [MINOR_VERSION_UPDATE] 현재 버전이 최신 버전의 마이너 버전이 낮음.
+     * @property [PATCH_VERSION_UPDATE] 현재 버전이 최신 버전의 패치 버전이 낮음.
+     * @property [LATEST_VERSION] 현재 버전이 최신 버전임.
+     */
+    enum class VersionCompareResult {
+        MAJOR_VERSION_UPDATE,
+        MINOR_VERSION_UPDATE,
+        PATCH_VERSION_UPDATE,
+        LATEST_VERSION,
+    }
+}

--- a/core/common/src/test/java/com/bff/wespot/common/util/AppVersionUtilsTest.kt
+++ b/core/common/src/test/java/com/bff/wespot/common/util/AppVersionUtilsTest.kt
@@ -1,0 +1,48 @@
+package com.bff.wespot.common.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AppVersionUtilsTest {
+    @Test
+    fun `메이저 버전 업데이트 테스트`() {
+        val result = AppVersionUtils.versionCompare("1.1.13", "2.3.2")
+        assertEquals(AppVersionUtils.VersionCompareResult.MAJOR_VERSION_UPDATE, result)
+    }
+
+    @Test
+    fun `마이너 버전 업데이트 테스트`() {
+        val result = AppVersionUtils.versionCompare("1.2.23", "1.3.0")
+        assertEquals(AppVersionUtils.VersionCompareResult.MINOR_VERSION_UPDATE, result)
+    }
+
+    @Test
+    fun `패치 버전 업데이트 테스트`() {
+        val result = AppVersionUtils.versionCompare("1.2.3", "1.2.4")
+        assertEquals(AppVersionUtils.VersionCompareResult.PATCH_VERSION_UPDATE, result)
+    }
+
+    @Test
+    fun `최신 버전 업데이트 테스트`() {
+        val result = AppVersionUtils.versionCompare("1.2.3", "1.2.3")
+        assertEquals(AppVersionUtils.VersionCompareResult.LATEST_VERSION, result)
+    }
+
+    @Test
+    fun `앱 버전이 더 높은 경우 테스트 `() {
+        val result = AppVersionUtils.versionCompare("2.3.1", "1.2.3")
+        assertEquals(AppVersionUtils.VersionCompareResult.LATEST_VERSION, result)
+    }
+
+    @Test
+    fun `앱 버전 중 패치 버전이 생략된 경우 테스트`() {
+        val result = AppVersionUtils.versionCompare("1.2", "1.2.1")
+        assertEquals(AppVersionUtils.VersionCompareResult.PATCH_VERSION_UPDATE, result)
+    }
+
+    @Test
+    fun `비교 버전 중 패치 버전이 생략된 경우 테스트`() {
+        val result = AppVersionUtils.versionCompare("1.2.1", "1.2")
+        assertEquals(AppVersionUtils.VersionCompareResult.LATEST_VERSION, result)
+    }
+}

--- a/data-local/src/main/java/com/bff/wespot/data/local/source/ProfileDataSource.kt
+++ b/data-local/src/main/java/com/bff/wespot/data/local/source/ProfileDataSource.kt
@@ -1,7 +1,6 @@
 package com.bff.wespot.data.local.source
 
 import com.bff.wespot.model.user.response.Profile
-import com.bff.wespot.model.user.response.ProfileCharacter
 import kotlinx.coroutines.flow.Flow
 
 interface ProfileDataSource {
@@ -12,8 +11,6 @@ interface ProfileDataSource {
     suspend fun setProfile(profile: Profile)
 
     suspend fun updateIntroduction(introduction: String)
-
-    suspend fun updateProfileCharacter(profileCharacter: ProfileCharacter)
 
     suspend fun clearProfile()
 }

--- a/data-local/src/main/java/com/bff/wespot/data/local/source/ProfileDataSourceImpl.kt
+++ b/data-local/src/main/java/com/bff/wespot/data/local/source/ProfileDataSourceImpl.kt
@@ -5,7 +5,6 @@ import com.bff.wespot.data.local.ProfilePreference
 import com.bff.wespot.data.local.common.mapper.toProfile
 import com.bff.wespot.data.local.copy
 import com.bff.wespot.model.user.response.Profile
-import com.bff.wespot.model.user.response.ProfileCharacter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
@@ -55,17 +54,6 @@ class ProfileDataSourceImpl @Inject constructor(
         preference.updateData {
             it.copy {
                 this.introduction = introduction
-            }
-        }
-    }
-
-    override suspend fun updateProfileCharacter(profileCharacter: ProfileCharacter) {
-        preference.updateData {
-            it.copy {
-                this.profileCharacter = it.profileCharacter.toBuilder()
-                    .setIconUrl(profileCharacter.iconUrl)
-                    .setBackgroundColor(profileCharacter.backgroundColor)
-                    .build()
             }
         }
     }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/CommonDataSource.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/CommonDataSource.kt
@@ -1,6 +1,5 @@
 package com.bff.wespot.data.remote.source
 
-import com.bff.wespot.data.remote.model.common.EditProfileDto
 import com.bff.wespot.data.remote.model.common.ImageUrlDto
 import com.bff.wespot.data.remote.model.common.KakaoContentDto
 import com.bff.wespot.data.remote.model.common.ProfanityDto
@@ -9,10 +8,8 @@ import com.bff.wespot.data.remote.model.common.RestrictionDto
 
 interface CommonDataSource {
     suspend fun checkProfanity(content: ProfanityDto): Result<Unit>
+
     suspend fun sendReport(report: ReportDto): Result<Unit>
-    suspend fun editProfile(
-        profile: EditProfileDto
-    ): Result<Unit>
 
     suspend fun getKakaoContent(type: String): Result<KakaoContentDto>
 

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/CommonDataSourceImpl.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/CommonDataSourceImpl.kt
@@ -1,6 +1,5 @@
 package com.bff.wespot.data.remote.source
 
-import com.bff.wespot.data.remote.model.common.EditProfileDto
 import com.bff.wespot.data.remote.model.common.ImageUrlDto
 import com.bff.wespot.data.remote.model.common.KakaoContentDto
 import com.bff.wespot.data.remote.model.common.ProfanityDto
@@ -35,15 +34,6 @@ class CommonDataSourceImpl @Inject constructor(
                 method = HttpMethod.Post
                 path("api/v1/reports")
                 setBody(report)
-            }
-        }
-
-    override suspend fun editProfile(profile: EditProfileDto): Result<Unit> =
-        httpClient.safeRequest {
-            url {
-                method = HttpMethod.Put
-                path("api/v1/users/me")
-                setBody(profile)
             }
         }
 

--- a/data/src/main/kotlin/com/bff/wespot/data/repository/CommonRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/repository/CommonRepositoryImpl.kt
@@ -26,21 +26,6 @@ class CommonRepositoryImpl @Inject constructor(
         content: String?,
     ): Result<Unit> = commonDataSource.sendReport(ReportDto(targetId, report, content))
 
-    override suspend fun editProfile(
-        introduction: String,
-        backgroundColor: String,
-        iconUrl: String
-    ): Result<Unit> =
-        commonDataSource.editProfile(
-            EditProfileDto(
-                introduction,
-                UpdateProfileDto(
-                    backgroundColor,
-                    iconUrl
-                )
-            )
-        )
-
     override suspend fun getKakaoContent(type: String): Result<KakaoContent> =
         commonDataSource.getKakaoContent(type)
             .mapCatching { it.toKakaoContent() }

--- a/data/src/main/kotlin/com/bff/wespot/data/repository/user/ProfileRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/repository/user/ProfileRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.bff.wespot.data.local.source.ProfileDataSource
 import com.bff.wespot.data.remote.source.user.UserDataSource
 import com.bff.wespot.domain.repository.user.ProfileRepository
 import com.bff.wespot.model.user.response.Profile
-import com.bff.wespot.model.user.response.ProfileCharacter
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -21,9 +20,6 @@ class ProfileRepositoryImpl @Inject constructor(
 
     override suspend fun updateIntroduction(introduction: String) =
         profileDataSource.updateIntroduction(introduction)
-
-    override suspend fun updateProfileCharacter(profileCharacter: ProfileCharacter) =
-        profileDataSource.updateProfileCharacter(profileCharacter)
 
     override suspend fun clearProfile() = profileDataSource.clearProfile()
 

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
 dependencies {
     implementation(project(":core:model"))
+    implementation(project(":core:common"))
 
     implementation(libs.paging3.domain)
     implementation(libs.java.inject)

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/CommonRepository.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/CommonRepository.kt
@@ -7,11 +7,6 @@ import com.bff.wespot.model.common.Restriction
 interface CommonRepository {
     suspend fun checkProfanity(content: String): Result<Unit>
     suspend fun sendReport(report: ReportType, targetId: Int, content: String? = null): Result<Unit>
-    suspend fun editProfile(
-        introduction: String,
-        backgroundColor: String,
-        iconUrl: String,
-    ): Result<Unit>
     suspend fun getKakaoContent(type: String): Result<KakaoContent>
     suspend fun getRestriction(): Result<Restriction>
     suspend fun uploadImage(imagePath: String): Result<String>

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/user/ProfileRepository.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/user/ProfileRepository.kt
@@ -1,7 +1,6 @@
 package com.bff.wespot.domain.repository.user
 
 import com.bff.wespot.model.user.response.Profile
-import com.bff.wespot.model.user.response.ProfileCharacter
 import kotlinx.coroutines.flow.Flow
 
 interface ProfileRepository {
@@ -12,8 +11,6 @@ interface ProfileRepository {
     suspend fun setProfile(profile: Profile)
 
     suspend fun updateIntroduction(introduction: String)
-
-    suspend fun updateProfileCharacter(profileCharacter: ProfileCharacter)
 
     suspend fun clearProfile()
 

--- a/domain/src/main/kotlin/com/bff/wespot/domain/usecase/AutoLoginUseCase.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/usecase/AutoLoginUseCase.kt
@@ -1,5 +1,7 @@
 package com.bff.wespot.domain.usecase
 
+import com.bff.wespot.common.util.AppVersionUtils.VersionCompareResult
+import com.bff.wespot.common.util.AppVersionUtils.versionCompare
 import com.bff.wespot.domain.repository.DataStoreRepository
 import com.bff.wespot.domain.repository.firebase.config.RemoteConfigRepository
 import com.bff.wespot.domain.util.DataStoreKey
@@ -17,7 +19,7 @@ class AutoLoginUseCase @Inject constructor(
     suspend operator fun invoke(versionName: String): LoginState {
         val minVersion = remoteConfigRepository.fetchFromRemoteConfig(RemoteConfigKey.MIN_VERSION)
 
-        if (versionCompare(minVersion, versionName)) {
+        if (versionCompare(versionName, minVersion) != VersionCompareResult.LATEST_VERSION) {
             return LoginState.FORCE_UPDATE
         }
 
@@ -34,22 +36,5 @@ class AutoLoginUseCase @Inject constructor(
                 LoginState.LOGIN_SUCCESS
             }
         }
-    }
-
-    private fun versionCompare(minVersion: String, appVersion: String): Boolean {
-        val minVersionSplit = minVersion.split(".").map { it.toInt() }
-        val appVersionSplit = appVersion.split(".").map { it.toInt() }
-
-        for (i in 0 until minOf(minVersionSplit.size, appVersionSplit.size)) {
-            if (minVersionSplit[i] > appVersionSplit[i]) {
-                return true
-            } else if (minVersionSplit[i] == appVersionSplit[i]) {
-                continue
-            } else {
-                return false
-            }
-        }
-
-        return minVersionSplit.size > appVersionSplit.size
     }
 }

--- a/domain/src/main/kotlin/com/bff/wespot/domain/util/DataStoreKey.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/util/DataStoreKey.kt
@@ -7,8 +7,6 @@ object DataStoreKey {
     const val SIGN_UP_TOKEN = "signup_token"
     const val PUSH_TOKEN = "push_token"
     const val VOTE_ONBOARDING = "vote_onboarding"
-
-    /** 마지막으로 버전 검사를 한 버전*/
     const val VERSION_LAST_CHECKED = "version_last_checked"
     const val NAME = "name"
     const val ID = "id"

--- a/domain/src/main/kotlin/com/bff/wespot/domain/util/DataStoreKey.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/util/DataStoreKey.kt
@@ -7,7 +7,9 @@ object DataStoreKey {
     const val SIGN_UP_TOKEN = "signup_token"
     const val PUSH_TOKEN = "push_token"
     const val VOTE_ONBOARDING = "vote_onboarding"
-    const val IS_NOTIFICATION_SET_UP = "is_notification_set_up"
+
+    /** 마지막으로 버전 검사를 한 버전*/
+    const val VERSION_LAST_CHECKED = "version_last_checked"
     const val NAME = "name"
     const val ID = "id"
 }

--- a/domain/src/main/kotlin/com/bff/wespot/domain/util/RemoteConfigKey.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/util/RemoteConfigKey.kt
@@ -2,6 +2,8 @@ package com.bff.wespot.domain.util
 
 object RemoteConfigKey {
     const val MIN_VERSION = "MIN_VERSION"
+    const val LATEST_VERSION = "ANDROID_LATEST_VERSION"
+    const val VERSION_UPDATE_TYPE = "ANDROID_VERSION_UPDATE_TYPE"
     const val BASE_URL = "BASE_URL"
     const val MOCK_BASE_URL = "MOCK_BASE_URL"
     const val VOTE_QUESTION_GOOGLE_FORM_URL = "VOTE_QUESTION_GOOGLE_FORM_URL"

--- a/feature/auth/src/main/kotlin/com/bff/wespot/auth/AuthActivity.kt
+++ b/feature/auth/src/main/kotlin/com/bff/wespot/auth/AuthActivity.kt
@@ -34,6 +34,7 @@ import com.bff.wespot.auth.state.AuthSideEffect
 import com.bff.wespot.auth.viewmodel.AuthViewModel
 import com.bff.wespot.designsystem.component.indicator.WSToastType
 import com.bff.wespot.designsystem.component.modal.WSDialog
+import com.bff.wespot.designsystem.component.modal.WSDialogType
 import com.bff.wespot.designsystem.theme.WeSpotTheme
 import com.bff.wespot.model.constants.LoginState
 import com.bff.wespot.navigation.Navigator
@@ -164,14 +165,11 @@ class AuthActivity : ComponentActivity() {
                         title = stringResource(R.string.new_version),
                         subTitle = stringResource(R.string.update_to_new_version),
                         okButtonText = stringResource(R.string.update),
-                        cancelButtonText = stringResource(R.string.cancel),
                         okButtonClick = {
                             navigator.navigateToWebLink(context, state.playStoreLink)
                         },
-                        cancelButtonClick = {
-                            finish()
-                        },
                         onDismissRequest = {},
+                        dialogType = WSDialogType.OneButton,
                     )
                 }
             }

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -5,8 +5,8 @@
     <string name="onboarding3">매일 저녁, 딱 세 통만 보낼 수 있는\n비밀 쪽지로 마음을 표현해 보세요!</string>
     <string name="onboarding_background">온보딩 배경</string>
     <string name="register_done">회원가입 완료</string>
-    <string name="new_version">세로운 버전 출시</string>
-    <string name="update_to_new_version">업데이트를 하고 새로운 기능을 만나보세요.</string>
+    <string name="new_version">세로운 버전이 업데이트 되었어요!</string>
+    <string name="update_to_new_version">위스팟을 계속 이용하시려면 최신 버전 업데이트가 필요해요 지금 바로 업데이트 하고 새로운 위스팟을 만나러 가볼까요?</string>
     <string name="update">업데이트</string>
     <string name="set_image">%1$s을 잘 나타 수 있는\n프로필을 선택 해 주세요</string>
     <string name="introduction_placeholder">(ex. 귀염둥이 엥뿌삐 ENFP)</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ firebase = "33.5.1"
 
 junit = "4.13.2"
 junit-version = "1.2.1"
+junit-jupitor = "5.11.3"
 espresso-core = "3.6.1"
 appcompat = "1.7.0"
 
@@ -119,6 +120,7 @@ firebase-config = { module = "com.google.firebase:firebase-config-ktx" }
 firebase-performance = { module = "com.google.firebase:firebase-perf" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+junit-jupitor = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupitor"}
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junit-version" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber"}


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#211 : 업데이트 유도 모달 추가해요.

RemoteConfig에 저장된 MIN_VERSION, LATEST_VERSION을 현재 버전과 대조해서, 

업데이트 유도모달을 노출해요 

## 2. 🔥 변경된 점

> 패치 버전 업데이트는 생략
> MIN_VERSION보다 낮은 경우 -> (강제) 기능 추가 모달 - 노출 시점 : 앱 진입-로그인 전(온보딩)
> 메이저, 마이너 버전 업데이트 -> (선택) 상황에 따라 기능 추가/버그 개선 모달 중 사용 - 노출 시점 : 메인 화면 진입 (투표 홈)
> **단, 선택 업데이트는 한 건에 대해 한 번만 노출/유저가 취소 누르면 다시 노출하지 않음
- [ [관련스레드](https://discord.com/channels/1241364675657203742/1311243791088226304/1311950070769258616) ] 

## 3. ✅ 필수 체크 사항 

1. 버전 검사 공통 유틸 클래스를 구현했어요.
- 관련해서 테스트 케이스도 구성해봤습니다잇
- common 모듈 내에 넣었는데요, 도메인 모듈에서 common 모듈 의존성이 추가되었어요. 
- 현재 common이 순수 kotlin common이라, 관계 없을 것 같긴한데요. 이전에 말했던 common-kotlin, common-android 나누는 거 생각해보면 좋을 것 같아용! 

2. 미사용 함수 소거 
- CommonRepostioy의 editProfile, profileRepository updateProfileCharacter 함수 소거했어요 

3. RemoteConfig에 UpdateType 추가 
- 아직 정해지지 않은 사항인데요, 일단 먼저 구현해두었습니다 ! 나중에 서버에서 받아오는 걸로 바뀔 수 있어요.

## 4. 📸 작업물 사진 공유(선택)
<img width="436" alt="스크린샷 2024-12-01 오후 9 23 01" src="https://github.com/user-attachments/assets/f032c972-1e61-4495-ac81-91860daf19ec">
<img width="450" alt="스크린샷 2024-12-01 오후 8 54 28" src="https://github.com/user-attachments/assets/51fb79ff-8ec1-47fb-962b-4611127aef1c">
<img width="452" alt="스크린샷 2024-12-01 오후 9 11 18" src="https://github.com/user-attachments/assets/4b7682e0-b8f6-4bdd-b71e-638f5fcb3286">

## 5. 💡알게된 혹은 궁금한 사항

나중에 app 모듈이랑 ui 모듈 정리 한번 합시다 ! 
app은 navigation 관련 로직 패키지로 분리하든 모듈로 분리하든 

ui는 compose 관련, android 관련 유틸함수들 분리 하는 걸로요 !

