### PR TITLE
#214 : LocalLifecycleOwner deprecated 대응해요

### DIFF
--- a/core/ui/src/main/kotlin/com/bff/wespot/ui/util/LifecycleUtil.kt
+++ b/core/ui/src/main/kotlin/com/bff/wespot/ui/util/LifecycleUtil.kt
@@ -3,10 +3,10 @@ package com.bff.wespot.ui.util
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 
 @Composable
 fun OnLifecycleEvent(onEvent: (owner: LifecycleOwner, event: Lifecycle.Event) -> Unit) {

--- a/core/ui/src/main/kotlin/com/bff/wespot/ui/util/SideEffectFlow.kt
+++ b/core/ui/src/main/kotlin/com/bff/wespot/ui/util/SideEffectFlow.kt
@@ -7,8 +7,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.bff.wespot.ui.component.SideEffectHandler
 import com.bff.wespot.ui.model.SideEffect


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#214 LifecycleOwner Deprecated 대응해요 

## 2. 🔥 변경된 점
LifecycleOwner import path가 변경되었어요.

<img width="508" alt="image" src="https://github.com/user-attachments/assets/65a194cf-c7d9-4c36-b0ca-b7a51d394af5" />


## 3. ✅ 필수 체크 사항 

https://github.com/wespot-bff/WeSpot-Android/pull/189
- 해당 라이브러리 버전 업데이트하면서, 변경된 것으로 보여용 

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡알게된 혹은 궁금한 사항

Android Studio 상단 탭 Code -> Analyze Code ->  Run Inspection by Name -> Deprecated API Usage로 Deprecated 메소드 찾을 수 있다. 
![image](https://github.com/user-attachments/assets/3345e620-8444-4c5f-85df-d50f64a3b3c0)

