### PR TITLE
#213 : 쪽지 내 버그 수정해요 

### DIFF
--- a/app/src/main/kotlin/com/bff/wespot/AppNavGraphs.kt
+++ b/app/src/main/kotlin/com/bff/wespot/AppNavGraphs.kt
@@ -128,13 +128,13 @@ object AppNavGraphs {
 
 private val bottomBarScreenNames = listOf(
     "vote/vote_home_screen",
-    "message/message_screen?toastMessage={toastMessage}&type={type}&messageId={messageId}",
+    "message/message_screen?type={type}&messageId={messageId}",
     "entire/entire_screen",
 )
 
 private val topBarScreenNames = listOf(
     "vote/vote_home_screen",
-    "message/message_screen?toastMessage={toastMessage}&type={type}&messageId={messageId}",
+    "message/message_screen&type={type}&messageId={messageId}",
     "entire/entire_screen",
 )
 
@@ -164,7 +164,7 @@ internal fun NavDestination.checkDestination(position: NavigationBarPosition): B
                 when (destination.route) {
                     "entire/entire_screen" -> return BarType.ENTIRE
                     "vote/vote_home_screen" -> return BarType.DEFAULT
-                    "message/message_screen?toastMessage={toastMessage}&type={type}&messageId={messageId}" -> return BarType.DEFAULT
+                    "message/message_screen?type={type}&messageId={messageId}" -> return BarType.DEFAULT
                 }
             }
             BarType.NONE

--- a/app/src/main/kotlin/com/bff/wespot/CommonNavGraphNavigator.kt
+++ b/app/src/main/kotlin/com/bff/wespot/CommonNavGraphNavigator.kt
@@ -88,12 +88,6 @@ class CommonNavGraphNavigator(
         navController.navigate(MessageWriteScreenDestination(args) within navGraph)
     }
 
-    override fun navigateMessageScreen(args: MessageScreenArgs) {
-        navController.navigate(MessageScreenDestination(args) within navGraph) {
-            popUpTo((MessageScreenDestination(args) within navGraph).route) { inclusive = true }
-        }
-    }
-
     override fun popUpToMessageScreen() {
         navController.popBackStack(
             route = (MessageScreenDestination() within navGraph).route,

--- a/app/src/main/kotlin/com/bff/wespot/CommonNavGraphNavigator.kt
+++ b/app/src/main/kotlin/com/bff/wespot/CommonNavGraphNavigator.kt
@@ -23,7 +23,6 @@ import com.bff.wespot.message.screen.MessageReportNavigator
 import com.bff.wespot.message.screen.MessageReportScreenArgs
 import com.bff.wespot.message.screen.MessageScreenArgs
 import com.bff.wespot.message.screen.ReservedMessageNavigator
-import com.bff.wespot.message.screen.ReservedMessageScreenArgs
 import com.bff.wespot.message.screen.destinations.MessageEditScreenDestination
 import com.bff.wespot.message.screen.destinations.MessageReportScreenDestination
 import com.bff.wespot.message.screen.destinations.MessageScreenDestination
@@ -99,14 +98,15 @@ class CommonNavGraphNavigator(
         navController.navigate(MessageEditScreenDestination(args) within navGraph)
     }
 
-    override fun navigateToReservedMessageScreen(args: ReservedMessageScreenArgs) {
-        navController.navigate(ReservedMessageScreenDestination(args) within navGraph)
+    override fun navigateToReservedMessageScreen() {
+        navController.navigate(ReservedMessageScreenDestination() within navGraph)
     }
 
-    override fun navigateToReservedMessageScreenFromEdit(args: ReservedMessageScreenArgs) {
-        navController.navigate(ReservedMessageScreenDestination(args) within navGraph) {
-            popUpTo((ReservedMessageScreenDestination(args) within navGraph).route) { inclusive = true }
-        }
+    override fun popUpToReservedMessageScreen() {
+        navController.popBackStack(
+            route = (ReservedMessageScreenDestination() within navGraph).route,
+            inclusive = false
+        )
     }
 
     override fun navigateToVoteHome() {

--- a/app/src/main/kotlin/com/bff/wespot/CommonNavGraphNavigator.kt
+++ b/app/src/main/kotlin/com/bff/wespot/CommonNavGraphNavigator.kt
@@ -94,6 +94,10 @@ class CommonNavGraphNavigator(
         }
     }
 
+    override fun popUpToMessageScreen() {
+        navController.popBackStack(navGraph.startRoute.route, inclusive = false)
+    }
+
     override fun navigateMessageEditScreen(args: EditMessageScreenArgs) {
         navController.navigate(MessageEditScreenDestination(args) within navGraph)
     }

--- a/app/src/main/kotlin/com/bff/wespot/CommonNavGraphNavigator.kt
+++ b/app/src/main/kotlin/com/bff/wespot/CommonNavGraphNavigator.kt
@@ -95,7 +95,10 @@ class CommonNavGraphNavigator(
     }
 
     override fun popUpToMessageScreen() {
-        navController.popBackStack(navGraph.startRoute.route, inclusive = false)
+        navController.popBackStack(
+            route = (MessageScreenDestination() within navGraph).route,
+            inclusive = false,
+        )
     }
 
     override fun navigateMessageEditScreen(args: EditMessageScreenArgs) {

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageReportScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageReportScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.bff.wespot.designsystem.component.button.WSButton
 import com.bff.wespot.designsystem.component.header.WSTopBar
+import com.bff.wespot.designsystem.component.indicator.WSToastType
 import com.bff.wespot.designsystem.theme.StaticTypeScale
 import com.bff.wespot.designsystem.theme.WeSpotThemeManager
 import com.bff.wespot.message.R
@@ -33,9 +34,9 @@ import com.bff.wespot.message.model.ReportReason
 import com.bff.wespot.message.state.report.ReportAction
 import com.bff.wespot.message.state.report.ReportSideEffect
 import com.bff.wespot.message.viewmodel.ReportViewModel
-import com.bff.wespot.model.notification.NotificationType
 import com.bff.wespot.ui.component.ListBottomGradient
 import com.bff.wespot.ui.component.WSSelectionItem
+import com.bff.wespot.ui.model.ToastState
 import com.bff.wespot.ui.util.handleSideEffect
 import com.ramcosta.composedestinations.annotation.Destination
 import kotlinx.collections.immutable.persistentListOf
@@ -44,7 +45,7 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 
 interface MessageReportNavigator {
     fun navigateUp()
-    fun navigateMessageScreen(args: MessageScreenArgs)
+    fun popUpToMessageScreen()
 }
 
 data class MessageReportScreenArgs(
@@ -56,6 +57,7 @@ data class MessageReportScreenArgs(
 @Composable
 fun MessageReportScreen(
     viewModel: ReportViewModel = hiltViewModel(),
+    showToast: (ToastState) -> Unit,
     navigator: MessageReportNavigator,
 ) {
     val scrollState = rememberScrollState()
@@ -67,11 +69,16 @@ fun MessageReportScreen(
 
     viewModel.collectSideEffect {
         when (it) {
-            is ReportSideEffect.NavigateToMessage -> {
-                navigator.navigateMessageScreen(
-                    args = MessageScreenArgs(
-                        toastMessage = R.string.report_message_success,
-                        type = NotificationType.MESSAGE_RECEIVED,
+            ReportSideEffect.NavigateToMessage -> {
+                navigator.popUpToMessageScreen()
+            }
+
+            is ReportSideEffect.ShowToast -> {
+                showToast(
+                    ToastState(
+                        message = it.message,
+                        show = true,
+                        type = WSToastType.Success,
                     ),
                 )
             }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageScreen.kt
@@ -33,7 +33,7 @@ interface MessageNavigator {
     fun navigateUp()
     fun navigateMessageReportScreen(args: MessageReportScreenArgs)
     fun navigateReceiverSelectionScreen(args: ReceiverSelectionScreenArgs)
-    fun navigateToReservedMessageScreen(args: ReservedMessageScreenArgs)
+    fun navigateToReservedMessageScreen()
 }
 
 data class MessageScreenArgs(
@@ -77,9 +77,7 @@ internal fun MessageScreen(
                     HOME_SCREEN_INDEX -> {
                         MessageHomeScreen(
                             navigateToReservedMessageScreen = {
-                                messageNavigator.navigateToReservedMessageScreen(
-                                    args = ReservedMessageScreenArgs(false),
-                                )
+                                messageNavigator.navigateToReservedMessageScreen()
                             },
                             navigateToMessageStorageScreen = {
                                 selectedTabIndex = STORAGE_SCREEN_INDEX
@@ -98,9 +96,7 @@ internal fun MessageScreen(
                             type = navArgs.type,
                             messageId = navArgs.messageId,
                             navigateToReservedMessageScreen = {
-                                messageNavigator.navigateToReservedMessageScreen(
-                                    args = ReservedMessageScreenArgs(false),
-                                )
+                                messageNavigator.navigateToReservedMessageScreen()
                             },
                             navigateToMessageReportScreen = { args ->
                                 messageNavigator.navigateMessageReportScreen(args)

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageScreen.kt
@@ -1,6 +1,5 @@
 package com.bff.wespot.message.screen
 
-import androidx.annotation.StringRes
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,7 +14,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.bff.wespot.designsystem.component.indicator.WSHomeTabRow
-import com.bff.wespot.designsystem.component.indicator.WSToastType
 import com.bff.wespot.message.R
 import com.bff.wespot.message.common.HOME_SCREEN_INDEX
 import com.bff.wespot.message.common.STORAGE_SCREEN_INDEX
@@ -37,7 +35,6 @@ interface MessageNavigator {
 }
 
 data class MessageScreenArgs(
-    @StringRes val toastMessage: Int? = null,
     val type: NotificationType = NotificationType.IDLE,
     val messageId: Int? = null,
 )
@@ -110,16 +107,6 @@ internal fun MessageScreen(
     }
 
     LaunchedEffect(Unit) {
-        if (navArgs.toastMessage != null) {
-            showToast(
-                ToastState(
-                    message = navArgs.toastMessage,
-                    show = true,
-                    type = WSToastType.Success,
-                ),
-            )
-        }
-
         when (navArgs.type) {
             NotificationType.MESSAGE_RECEIVED, NotificationType.MESSAGE_SENT -> {
                 selectedTabIndex = STORAGE_SCREEN_INDEX

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/ReservedMessageScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/ReservedMessageScreen.kt
@@ -13,9 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -23,7 +20,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bff.wespot.designsystem.component.header.WSTopBar
-import com.bff.wespot.designsystem.component.indicator.WSToastType
 import com.bff.wespot.designsystem.theme.StaticTypeScale
 import com.bff.wespot.designsystem.theme.WeSpotThemeManager
 import com.bff.wespot.message.R
@@ -35,7 +31,6 @@ import com.bff.wespot.message.viewmodel.SendViewModel
 import com.bff.wespot.ui.component.LoadingAnimation
 import com.bff.wespot.ui.component.NetworkDialog
 import com.bff.wespot.ui.component.ReservedMessageItem
-import com.bff.wespot.ui.component.TopToast
 import com.bff.wespot.ui.util.handleSideEffect
 import com.ramcosta.composedestinations.annotation.Destination
 import org.orbitmvi.orbit.compose.collectAsState
@@ -45,21 +40,14 @@ interface ReservedMessageNavigator {
     fun navigateMessageEditScreen(args: EditMessageScreenArgs)
 }
 
-data class ReservedMessageScreenArgs(
-    val isMessageEdit: Boolean,
-)
-
 @OptIn(ExperimentalMaterial3Api::class)
-@Destination(navArgsDelegate = ReservedMessageScreenArgs::class)
+@Destination
 @Composable
 fun ReservedMessageScreen(
     navigator: ReservedMessageNavigator,
-    navArgs: ReservedMessageScreenArgs,
     sendViewModel: SendViewModel,
     viewModel: MessageViewModel = hiltViewModel(),
 ) {
-    var showToast by remember { mutableStateOf(false) }
-
     val state by viewModel.collectAsState()
     val action = viewModel::onAction
 
@@ -121,19 +109,10 @@ fun ReservedMessageScreen(
         }
     }
 
-    TopToast(
-        message = stringResource(id = R.string.edit_done),
-        toastType = WSToastType.Success,
-        showToast = showToast,
-    ) {
-        showToast = false
-    }
-
     NetworkDialog(context = context, networkState = networkState)
 
     LaunchedEffect(Unit) {
         action(MessageAction.OnReservedMessageScreenEntered)
         sendViewModel.onAction(SendAction.OnReservedMessageScreenEntered)
-        showToast = navArgs.isMessageEdit
     }
 }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageEditScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageEditScreen.kt
@@ -40,7 +40,6 @@ import com.bff.wespot.designsystem.theme.StaticTypeScale
 import com.bff.wespot.designsystem.theme.WeSpotThemeManager
 import com.bff.wespot.message.R
 import com.bff.wespot.message.component.SendExitDialog
-import com.bff.wespot.message.screen.MessageScreenArgs
 import com.bff.wespot.message.state.send.SendAction
 import com.bff.wespot.message.state.send.SendSideEffect
 import com.bff.wespot.message.viewmodel.SendViewModel
@@ -58,7 +57,7 @@ interface MessageEditNavigator {
     fun navigateUp()
     fun navigateReceiverSelectionScreen(args: ReceiverSelectionScreenArgs)
     fun navigateMessageWriteScreen(args: MessageWriteScreenArgs)
-    fun navigateMessageScreen(args: MessageScreenArgs)
+    fun popUpToMessageScreen()
     fun popUpToReservedMessageScreen()
 }
 
@@ -96,25 +95,26 @@ fun MessageEditScreen(
                 reserveDialog = false
             }
 
-            is SendSideEffect.ShowTimeoutDialog -> {
+            SendSideEffect.ShowTimeoutDialog -> {
                 timeoutDialog = true
             }
 
-            is SendSideEffect.NavigateToMessage -> {
-                navigator.navigateMessageScreen(
-                    args = MessageScreenArgs(toastMessage = R.string.message_reserve_success),
-                )
+            SendSideEffect.NavigateToMessage -> {
+                navigator.popUpToMessageScreen()
             }
 
-            is SendSideEffect.NavigateToReservedMessage -> {
+            SendSideEffect.NavigateToReservedMessage -> {
+                navigator.popUpToReservedMessageScreen()
+            }
+
+            is SendSideEffect.ShowToast -> {
                 showToast(
                     ToastState(
-                        message = R.string.edit_done,
+                        message = it.message,
                         show = true,
                         type = WSToastType.Success,
                     ),
                 )
-                navigator.popUpToReservedMessageScreen()
             }
         }
     }
@@ -240,7 +240,7 @@ fun MessageEditScreen(
                 isReservedMessage = state.isReservedMessage,
                 okButtonClick = {
                     exitDialog = false
-                    navigator.navigateMessageScreen(args = MessageScreenArgs())
+                    navigator.popUpToMessageScreen()
                 },
                 cancelButtonClick = { exitDialog = false },
             )
@@ -264,9 +264,7 @@ fun MessageEditScreen(
                 subTitle = state.messageSendFailedDialogContent,
                 okButtonText = stringResource(R.string.positive_answer),
                 cancelButtonText = stringResource(R.string.close),
-                okButtonClick = {
-                    navigator.navigateMessageScreen(args = MessageScreenArgs())
-                },
+                okButtonClick = navigator::popUpToMessageScreen,
                 cancelButtonClick = { timeoutDialog = false },
                 onDismissRequest = { },
             )

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageEditScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageEditScreen.kt
@@ -41,7 +41,6 @@ import com.bff.wespot.designsystem.theme.WeSpotThemeManager
 import com.bff.wespot.message.R
 import com.bff.wespot.message.component.SendExitDialog
 import com.bff.wespot.message.screen.MessageScreenArgs
-import com.bff.wespot.message.screen.ReservedMessageScreenArgs
 import com.bff.wespot.message.state.send.SendAction
 import com.bff.wespot.message.state.send.SendSideEffect
 import com.bff.wespot.message.viewmodel.SendViewModel
@@ -49,6 +48,7 @@ import com.bff.wespot.ui.component.LetterCountIndicator
 import com.bff.wespot.ui.component.LoadingAnimation
 import com.bff.wespot.ui.component.NetworkDialog
 import com.bff.wespot.ui.component.TopToast
+import com.bff.wespot.ui.model.ToastState
 import com.bff.wespot.ui.util.handleSideEffect
 import com.ramcosta.composedestinations.annotation.Destination
 import org.orbitmvi.orbit.compose.collectAsState
@@ -59,7 +59,7 @@ interface MessageEditNavigator {
     fun navigateReceiverSelectionScreen(args: ReceiverSelectionScreenArgs)
     fun navigateMessageWriteScreen(args: MessageWriteScreenArgs)
     fun navigateMessageScreen(args: MessageScreenArgs)
-    fun navigateToReservedMessageScreenFromEdit(args: ReservedMessageScreenArgs)
+    fun popUpToReservedMessageScreen()
 }
 
 data class EditMessageScreenArgs(
@@ -73,6 +73,7 @@ data class EditMessageScreenArgs(
 fun MessageEditScreen(
     navigator: MessageEditNavigator,
     navArgs: EditMessageScreenArgs,
+    showToast: (ToastState) -> Unit,
     viewModel: SendViewModel,
 ) {
     var exitDialog by remember { mutableStateOf(false) }
@@ -106,9 +107,14 @@ fun MessageEditScreen(
             }
 
             is SendSideEffect.NavigateToReservedMessage -> {
-                navigator.navigateToReservedMessageScreenFromEdit(
-                    args = ReservedMessageScreenArgs(true),
+                showToast(
+                    ToastState(
+                        message = R.string.edit_done,
+                        show = true,
+                        type = WSToastType.Success,
+                    ),
                 )
+                navigator.popUpToReservedMessageScreen()
             }
         }
     }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageWriteScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageWriteScreen.kt
@@ -35,7 +35,6 @@ import com.bff.wespot.designsystem.theme.WeSpotThemeManager
 import com.bff.wespot.message.R
 import com.bff.wespot.message.common.MESSAGE_MAX_LENGTH
 import com.bff.wespot.message.component.SendExitDialog
-import com.bff.wespot.message.screen.MessageScreenArgs
 import com.bff.wespot.message.state.send.SendAction
 import com.bff.wespot.message.viewmodel.SendViewModel
 import com.bff.wespot.ui.component.LetterCountIndicator
@@ -47,7 +46,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 
 interface MessageWriteNavigator {
     fun navigateUp()
-    fun navigateMessageScreen(args: MessageScreenArgs)
+    fun popUpToMessageScreen()
     fun navigateMessageEditScreen(args: EditMessageScreenArgs)
 }
 
@@ -175,7 +174,7 @@ fun MessageWriteScreen(
             isReservedMessage = state.isReservedMessage,
             okButtonClick = {
                 dialogState = false
-                navigator.navigateMessageScreen(args = MessageScreenArgs())
+                navigator.popUpToMessageScreen()
             },
             cancelButtonClick = { dialogState = false },
         )

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
@@ -44,7 +44,6 @@ import com.bff.wespot.designsystem.theme.StaticTypeScale
 import com.bff.wespot.designsystem.theme.WeSpotThemeManager
 import com.bff.wespot.message.R
 import com.bff.wespot.message.component.SendExitDialog
-import com.bff.wespot.message.screen.MessageScreenArgs
 import com.bff.wespot.message.state.send.SendAction
 import com.bff.wespot.message.viewmodel.SendViewModel
 import com.bff.wespot.model.common.KakaoContent
@@ -60,7 +59,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 interface ReceiverSelectionNavigator {
     fun navigateUp()
     fun navigateMessageWriteScreen(args: MessageWriteScreenArgs)
-    fun navigateMessageScreen(args: MessageScreenArgs)
+    fun popUpToMessageScreen()
 }
 
 data class ReceiverSelectionScreenArgs(
@@ -240,7 +239,7 @@ fun ReceiverSelectionScreen(
             isReservedMessage = state.isReservedMessage,
             okButtonClick = {
                 dialogState = false
-                navigator.navigateMessageScreen(args = MessageScreenArgs())
+                navigator.popUpToMessageScreen()
             },
             cancelButtonClick = { dialogState = false },
         )

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
@@ -1,6 +1,5 @@
 package com.bff.wespot.message.screen.send
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -26,12 +25,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
@@ -51,6 +49,7 @@ import com.bff.wespot.message.state.send.SendAction
 import com.bff.wespot.message.viewmodel.SendViewModel
 import com.bff.wespot.model.common.KakaoContent
 import com.bff.wespot.navigation.Navigator
+import com.bff.wespot.ui.component.ListBottomGradient
 import com.bff.wespot.ui.component.NetworkDialog
 import com.bff.wespot.ui.component.WSListItem
 import com.bff.wespot.ui.util.handleSideEffect
@@ -178,7 +177,7 @@ fun ReceiverSelectionScreen(
             }
 
             LazyColumn(
-                modifier = Modifier.padding(top = 16.dp),
+                modifier = Modifier.padding(top = 16.dp, bottom = 74.dp),
             ) {
                 items(
                     pagingData.itemCount,
@@ -215,41 +214,25 @@ fun ReceiverSelectionScreen(
     }
 
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .imePadding(),
+        modifier = Modifier.fillMaxSize().imePadding().zIndex(1f),
         contentAlignment = Alignment.BottomCenter,
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(124.dp)
-                .background(
-                    brush = Brush.verticalGradient(
-                        colors = listOf(
-                            Color.Transparent,
-                            WeSpotThemeManager.colors.backgroundColor,
-                        ),
-                    ),
-                ),
-            contentAlignment = Alignment.BottomCenter,
-        ) {
-            WSButton(
-                onClick = {
-                    if (navArgs.isEditing) {
-                        navigator.navigateUp()
-                        return@WSButton
-                    }
-                    navigator.navigateMessageWriteScreen(
-                        args = MessageWriteScreenArgs(isEditing = false),
-                    )
-                },
-                enabled = state.selectedUser.name.isNotBlank(),
-                text = if (navArgs.isEditing) stringResource(R.string.edit_done) else stringResource(R.string.next),
-            ) {
-                it()
-            }
-        }
+        ListBottomGradient(height = 124)
+
+        WSButton(
+            onClick = {
+                if (navArgs.isEditing) {
+                    navigator.navigateUp()
+                    return@WSButton
+                }
+                navigator.navigateMessageWriteScreen(
+                    args = MessageWriteScreenArgs(isEditing = false),
+                )
+            },
+            enabled = state.selectedUser.name.isNotBlank(),
+            text = if (navArgs.isEditing) stringResource(R.string.edit_done) else stringResource(R.string.next),
+            content = { it() },
+        )
     }
 
     if (dialogState) {

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
@@ -213,7 +213,10 @@ fun ReceiverSelectionScreen(
     }
 
     Box(
-        modifier = Modifier.fillMaxSize().imePadding().zIndex(1f),
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding()
+            .zIndex(1f),
         contentAlignment = Alignment.BottomCenter,
     ) {
         ListBottomGradient(height = 124)

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/report/ReportSideEffect.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/report/ReportSideEffect.kt
@@ -1,5 +1,10 @@
 package com.bff.wespot.message.state.report
 
+import androidx.annotation.StringRes
+
 sealed interface ReportSideEffect {
     data object NavigateToMessage : ReportSideEffect
+    data class ShowToast(
+        @StringRes val message: Int,
+    ) : ReportSideEffect
 }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/send/SendSideEffect.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/send/SendSideEffect.kt
@@ -1,8 +1,13 @@
 package com.bff.wespot.message.state.send
 
+import androidx.annotation.StringRes
+
 sealed class SendSideEffect {
     data object NavigateToMessage : SendSideEffect()
     data object NavigateToReservedMessage : SendSideEffect()
     data object ShowTimeoutDialog : SendSideEffect()
     data object CloseReserveDialog : SendSideEffect()
+    data class ShowToast(
+        @StringRes val message: Int,
+    ) : SendSideEffect()
 }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/ReportViewModel.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/ReportViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bff.wespot.common.extension.onNetworkFailure
 import com.bff.wespot.domain.repository.CommonRepository
+import com.bff.wespot.message.R
 import com.bff.wespot.message.model.ReportReason
 import com.bff.wespot.message.state.report.ReportAction
 import com.bff.wespot.message.state.report.ReportSideEffect
@@ -68,6 +69,7 @@ class ReportViewModel @Inject constructor(
                 targetId = state.messageId,
                 content = reason,
             ).onSuccess {
+                postSideEffect(ReportSideEffect.ShowToast(R.string.report_message_success))
                 postSideEffect(ReportSideEffect.NavigateToMessage)
             }.onNetworkFailure {
                 postSideEffect(it.toSideEffect())

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/SendViewModel.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/SendViewModel.kt
@@ -11,6 +11,7 @@ import com.bff.wespot.domain.repository.CommonRepository
 import com.bff.wespot.domain.repository.message.MessageRepository
 import com.bff.wespot.domain.repository.user.ProfileRepository
 import com.bff.wespot.domain.usecase.CheckProfanityUseCase
+import com.bff.wespot.message.R
 import com.bff.wespot.message.common.MESSAGE_MAX_LENGTH
 import com.bff.wespot.message.state.send.SendAction
 import com.bff.wespot.message.state.send.SendSideEffect
@@ -217,6 +218,7 @@ class SendViewModel @Inject constructor(
             ).onSuccess {
                 trackMessageSendEvent()
                 reduce { state.copy(isLoading = false) }
+                postSideEffect(SendSideEffect.ShowToast(R.string.message_reserve_success))
                 postSideEffect(SendSideEffect.NavigateToMessage)
             }.onNetworkFailure { exception ->
                 if (exception.status == 400) {
@@ -265,6 +267,7 @@ class SendViewModel @Inject constructor(
                     isAnonymous = state.isRandomName,
                 ),
             ).onSuccess {
+                postSideEffect(SendSideEffect.ShowToast(R.string.edit_done))
                 postSideEffect(SendSideEffect.NavigateToReservedMessage)
             }.onNetworkFailure { exception ->
                 if (exception.status == 400) {


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#213 : 쪽지 버그 수정해요

## 2. 🔥 변경된 점

 1. 수정완료/작성완료/신고완료 토스트 노출 시점 변경
 2. 유저 선택 페이지 하단 아이템 짤리는 이슈 수정
 3. 쪽지 수정 후, 뒤로가기시 이전 작성 페이지로 전환되는 이슈 수정

## 3. ✅ 필수 체크 사항 

기존 MessageScreen에서 argument로 넘겨서 토스트를 노출하고 있었는데요 !

근데, showToast를 주입해주고 있어서, 굳이 넘길 필요가 없었어요. 

오히려 넘기면서 argument가 재사용되는 케이스가 있어서, 토스트가 중복 노출되는 경우 이슈가 있었어요. 
- 쪽지를 작성하고, 쪽지 홈으로 와서, 투표 탭으로 갔다가 뒤로가기하면 토스트가 중복 노출되었던 것 같아요. 
- showToast를 하면서, 화면 전환하도록 수정했어요. 

그리고 기존에 다 쪽지 홈으로 전환하기 위해서 MessageScreen으로 navigate하면서 popUpTo를 함께 해주고 있었는데, 
전부 popBackStack으로 처리하도록 수정했어요. 
- 둘 차이는 전환되기 전 화면이 백스택에 추가되는지 유무에요.
- 이 이슈로 인해서, 쪽지 수정 후 예약 페이지로 왔다가, 뒤로가기를 했을 때 쪽지 수정 페이지로 다시 전환되는 이슈가 있었어요. 

## 4. 📸 작업물 사진 공유(선택)

## 하단 버튼에 마지막 아이템 가려지는 이슈 수정 
![image](https://github.com/user-attachments/assets/97f5aac8-131c-4d13-83de-479ca0865f89)

## 쪽지 예약 후, 뒤로가기시 다시 쪽지 작성 페이지로 진입하는 이슈 수정 
[Screen_Recording_20250113-211155_WeSpot.webm](https://github.com/user-attachments/assets/f01b247c-ffad-4851-8476-b7ced5c3b063)

## 5. 💡알게된 혹은 궁금한 사항

궁금한데, 동적으로 높이를 계산해야 할까요 ? 

쪽지를 보낼 대상 선택 리스트의 맨 마지막 아이템이, 버튼에 가려지는 이슈가 있었는데요. 

해당 케이스의 경우 버튼 크기 만큼 고정 높이를 줘서 해결했는데, glboalPositioned, constraint, layout 이런걸로 계산해서 동적으로 수정해야할지 고민이에요. 
