### PR TITLE
Feature/#225

### DIFF
--- a/app/src/main/kotlin/com/bff/wespot/splash/SplashViewModel.kt
+++ b/app/src/main/kotlin/com/bff/wespot/splash/SplashViewModel.kt
@@ -3,7 +3,6 @@ package com.bff.wespot.splash
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bff.wespot.domain.repository.firebase.config.RemoteConfigRepository
-import com.bff.wespot.domain.util.RemoteConfigKey
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,20 +11,14 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val dataSource: RemoteConfigRepository
+    private val remoteConfigRepository: RemoteConfigRepository,
 ) : ViewModel() {
     private val _start = MutableStateFlow(false)
     val start = _start.asStateFlow()
 
-    private val _minVersion = MutableStateFlow("")
-    val minVersion = _minVersion.asStateFlow()
-
     init {
         viewModelScope.launch {
-            _start.value = dataSource.startRemoteConfig()
-            if (_start.value) {
-                _minVersion.emit(dataSource.fetchFromRemoteConfig(RemoteConfigKey.MIN_VERSION))
-            }
+            _start.value = remoteConfigRepository.startRemoteConfig()
         }
     }
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/extensions/TaskExtensions.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/extensions/TaskExtensions.kt
@@ -1,0 +1,23 @@
+package com.bff.wespot.data.remote.extensions
+
+import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import timber.log.Timber
+import kotlin.coroutines.resumeWithException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+suspend fun <T> Task<T>.await(): T {
+    return suspendCancellableCoroutine { cont ->
+        addOnCompleteListener {
+            val exception = it.exception
+            if (exception != null) {
+                cont.resumeWithException(exception)
+                Timber.e(exception)
+            } else {
+                cont.resume(it.result, null)
+                Timber.d(it.result.toString())
+            }
+        }
+    }
+}

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/firebase/messaging/MessagingDataSource.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/firebase/messaging/MessagingDataSource.kt
@@ -2,4 +2,8 @@ package com.bff.wespot.data.remote.source.firebase.messaging
 
 interface MessagingDataSource {
     suspend fun getFcmToken(): String
+
+    suspend fun removeFcmToken()
+
+    suspend fun initMessaging()
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/firebase/messaging/MessagingDataSource.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/firebase/messaging/MessagingDataSource.kt
@@ -4,6 +4,4 @@ interface MessagingDataSource {
     suspend fun getFcmToken(): String
 
     suspend fun removeFcmToken()
-
-    suspend fun initMessaging()
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/firebase/messaging/MessagingDataSourceImpl.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/firebase/messaging/MessagingDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.bff.wespot.data.remote.source.firebase.messaging
 
+import com.bff.wespot.data.remote.extensions.await
 import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
@@ -16,5 +17,14 @@ class MessagingDataSourceImpl @Inject constructor(
                 Timber.e("Update FcmToken Failed Exception : ", it)
             }
         }
+    }
+
+    override suspend fun removeFcmToken() {
+        messaging.isAutoInitEnabled = false
+        messaging.deleteToken().await()
+    }
+
+    override suspend fun initMessaging() {
+        messaging.isAutoInitEnabled = true
     }
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/firebase/messaging/MessagingDataSourceImpl.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/firebase/messaging/MessagingDataSourceImpl.kt
@@ -2,29 +2,18 @@ package com.bff.wespot.data.remote.source.firebase.messaging
 
 import com.bff.wespot.data.remote.extensions.await
 import com.google.firebase.messaging.FirebaseMessaging
-import kotlinx.coroutines.suspendCancellableCoroutine
-import timber.log.Timber
 import javax.inject.Inject
 
 class MessagingDataSourceImpl @Inject constructor(
     private val messaging: FirebaseMessaging,
 ) : MessagingDataSource {
     override suspend fun getFcmToken(): String {
-        return suspendCancellableCoroutine { continuation ->
-            messaging.token.addOnCompleteListener {
-                continuation.resumeWith(Result.success(it.result))
-            }.addOnFailureListener {
-                Timber.e("Update FcmToken Failed Exception : ", it)
-            }
-        }
+        messaging.isAutoInitEnabled = true
+        return messaging.token.await()
     }
 
     override suspend fun removeFcmToken() {
         messaging.isAutoInitEnabled = false
         messaging.deleteToken().await()
-    }
-
-    override suspend fun initMessaging() {
-        messaging.isAutoInitEnabled = true
     }
 }

--- a/data/src/main/kotlin/com/bff/wespot/data/repository/firebase/messaging/MessagingRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/repository/firebase/messaging/MessagingRepositoryImpl.kt
@@ -10,6 +10,4 @@ class MessagingRepositoryImpl @Inject constructor(
     override suspend fun getFcmToken(): String = messagingDataSource.getFcmToken()
 
     override suspend fun removeFcmToken() = messagingDataSource.removeFcmToken()
-
-    override suspend fun initMessaging() = messagingDataSource.initMessaging()
 }

--- a/data/src/main/kotlin/com/bff/wespot/data/repository/firebase/messaging/MessagingRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/repository/firebase/messaging/MessagingRepositoryImpl.kt
@@ -8,4 +8,8 @@ class MessagingRepositoryImpl @Inject constructor(
     private val messagingDataSource: MessagingDataSource,
 ): MessagingRepository {
     override suspend fun getFcmToken(): String = messagingDataSource.getFcmToken()
+
+    override suspend fun removeFcmToken() = messagingDataSource.removeFcmToken()
+
+    override suspend fun initMessaging() = messagingDataSource.initMessaging()
 }

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/firebase/messaging/MessagingRepository.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/firebase/messaging/MessagingRepository.kt
@@ -2,4 +2,8 @@ package com.bff.wespot.domain.repository.firebase.messaging
 
 interface MessagingRepository {
     suspend fun getFcmToken(): String
+
+    suspend fun removeFcmToken()
+
+    suspend fun initMessaging()
 }

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/firebase/messaging/MessagingRepository.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/firebase/messaging/MessagingRepository.kt
@@ -4,6 +4,4 @@ interface MessagingRepository {
     suspend fun getFcmToken(): String
 
     suspend fun removeFcmToken()
-
-    suspend fun initMessaging()
 }

--- a/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
@@ -7,6 +7,7 @@ import com.bff.wespot.domain.repository.BasePagingRepository
 import com.bff.wespot.domain.repository.DataStoreRepository
 import com.bff.wespot.domain.repository.auth.AuthRepository
 import com.bff.wespot.domain.repository.firebase.config.RemoteConfigRepository
+import com.bff.wespot.domain.repository.firebase.messaging.MessagingRepository
 import com.bff.wespot.domain.repository.message.MessageStorageRepository
 import com.bff.wespot.domain.repository.user.ProfileRepository
 import com.bff.wespot.domain.util.RemoteConfigKey
@@ -22,6 +23,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -35,6 +37,7 @@ class EntireViewModel @Inject constructor(
     private val profileRepository: ProfileRepository,
     private val authRepository: AuthRepository,
     private val remoteConfigRepository: RemoteConfigRepository,
+    private val messagingRepository: MessagingRepository,
     private val messageStorageRepository: MessageStorageRepository,
     private val dataStoreRepository: DataStoreRepository,
     private val messageBlockedRepository: BasePagingRepository<BlockedMessage, Paging<BlockedMessage>>,
@@ -124,9 +127,12 @@ class EntireViewModel @Inject constructor(
     }
 
     private fun clearCachedData() {
-        viewModelScope.launch {
-            launch { dataStoreRepository.clear() }
-            launch { profileRepository.clearProfile() }
+        viewModelScope.launch(coroutineDispatcher) {
+            supervisorScope {
+                launch { dataStoreRepository.clear() }
+                launch { profileRepository.clearProfile() }
+                launch { messagingRepository.removeFcmToken() }
+            }
         }
     }
 


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#225 : 로그아웃시 알림 받지 않도록 수정해요.

## 2. 🔥 변경된 점
로그아웃 시, 토큰과 관련 속성을 소거했어요 

로그아웃 전, 로그아웃 후 토큰 값 바뀌는 점 확인했습니다.

로그아웃된 상태에서 알림이 오지 않는 점 확인했습니다. 


## 3. ✅ 필수 체크 사항 

로그아웃 / 회원탈퇴에서 캐시 날리던 부분 iO 스레드, supervisorScope로 한번 감쌌습니다. 

Firebase SuspendCoroutine은 하나 익스텐션 만들어서 함꼐 처리했어요 

SplashViewModel 내 minVersion 사용하는 곳이 없어서 소거했습니다. 

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡알게된 혹은 궁금한 사항
