### PR TITLE
#225 : 로그아웃 API 구현해요

### DIFF
--- a/core/ui/src/main/kotlin/com/bff/wespot/ui/base/BaseViewModel.kt
+++ b/core/ui/src/main/kotlin/com/bff/wespot/ui/base/BaseViewModel.kt
@@ -18,7 +18,7 @@ open class BaseViewModel : ViewModel() {
     val networkState
         get() = networkStateChecker.networkState
 
-    private val _sideEffect = Channel<SideEffect>()
+    private val _sideEffect = Channel<SideEffect>(Channel.BUFFERED)
     val sideEffect = _sideEffect.receiveAsFlow()
 
     protected suspend fun postSideEffect(sideEffect: SideEffect) = _sideEffect.send(sideEffect)

--- a/core/ui/src/main/kotlin/com/bff/wespot/ui/util/KakaoLoginManager.kt
+++ b/core/ui/src/main/kotlin/com/bff/wespot/ui/util/KakaoLoginManager.kt
@@ -85,9 +85,17 @@ class KakaoLoginManager {
     companion object {
         fun logout() = UserApiClient.instance.logout { error ->
             if (error != null) {
-                Timber.d("로그아웃 실패. SDK에서 토큰 삭제됨")
+                Timber.e("Kakao 로그아웃 실패. SDK에서 토큰 삭제됨 : $error")
             } else {
-                Timber.d("로그아웃 성공. SDK에서 토큰 삭제됨")
+                Timber.d("Kakao 로그아웃 성공. SDK에서 토큰 삭제됨")
+            }
+        }
+
+        fun revoke() = UserApiClient.instance.unlink { error ->
+            if (error != null) {
+                Timber.e("Kakao 탈퇴 실패 : $error")
+            } else {
+                Timber.d("Kakao 탈퇴 성공. SDK에서 토큰 삭제됨")
             }
         }
     }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/auth/AuthDataSource.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/auth/AuthDataSource.kt
@@ -11,4 +11,5 @@ interface AuthDataSource {
     suspend fun signIn(signIn: SignInDto): Result<Any>
     suspend fun signUp(signUp: SignUpDto): Result<AuthTokenDto>
     suspend fun revoke(revokeReasonList: RevokeReasonListDto): Result<Unit>
+    suspend fun signOut(): Result<Unit>
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/auth/AuthDataSourceImpl.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/auth/AuthDataSourceImpl.kt
@@ -60,4 +60,12 @@ class AuthDataSourceImpl @Inject constructor(
             }
             setBody(revokeReasonList)
         }
+
+    override suspend fun signOut(): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Patch
+                path("api/v1/auth/logout")
+            }
+        }
 }

--- a/data/src/main/kotlin/com/bff/wespot/data/repository/auth/AuthRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/repository/auth/AuthRepositoryImpl.kt
@@ -61,4 +61,6 @@ class AuthRepositoryImpl @Inject constructor(
             RevokeReasonListDto(revokeReasons = revokeReasonList)
         )
     }
+
+    override suspend fun signOut(): Result<Unit> = authDataSource.signOut()
 }

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/auth/AuthRepository.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/auth/AuthRepository.kt
@@ -7,4 +7,5 @@ interface AuthRepository {
     suspend fun signIn(signIn: SignIn): Result<Any>
     suspend fun signUp(signUp: SignUp): Boolean
     suspend fun revoke(revokeReasonList: List<String>): Result<Unit>
+    suspend fun signOut(): Result<Unit>
 }

--- a/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/AccountSettingScreen.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/AccountSettingScreen.kt
@@ -63,6 +63,7 @@ fun AccountSettingScreen(
             is EntireSideEffect.CloseSignOutDialog -> {
                 showDialog = false
             }
+            is EntireSideEffect.CloseRevokeDialog -> { }
         }
     }
 

--- a/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/AccountSettingScreen.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/AccountSettingScreen.kt
@@ -28,6 +28,7 @@ import com.bff.wespot.entire.state.EntireSideEffect
 import com.bff.wespot.entire.viewmodel.EntireViewModel
 import com.bff.wespot.navigation.Navigator
 import com.bff.wespot.ui.component.LoadingAnimation
+import com.bff.wespot.ui.util.handleSideEffect
 import com.ramcosta.composedestinations.annotation.Destination
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -50,6 +51,8 @@ fun AccountSettingScreen(
 
     val action = viewModel::onAction
     val state by viewModel.collectAsState()
+
+    handleSideEffect(viewModel.sideEffect)
 
     viewModel.collectSideEffect {
         when (it) {

--- a/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/AccountSettingScreen.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/AccountSettingScreen.kt
@@ -60,6 +60,9 @@ fun AccountSettingScreen(
                 val intent = activityNavigator.navigateToAuth(context)
                 context.startActivity(intent)
             }
+            is EntireSideEffect.CloseSignOutDialog -> {
+                showDialog = false
+            }
         }
     }
 

--- a/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/AccountSettingScreen.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/AccountSettingScreen.kt
@@ -27,7 +27,9 @@ import com.bff.wespot.entire.state.EntireAction
 import com.bff.wespot.entire.state.EntireSideEffect
 import com.bff.wespot.entire.viewmodel.EntireViewModel
 import com.bff.wespot.navigation.Navigator
+import com.bff.wespot.ui.component.LoadingAnimation
 import com.ramcosta.composedestinations.annotation.Destination
+import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
 interface AccountSettingNavigator {
@@ -47,6 +49,7 @@ fun AccountSettingScreen(
     var showDialog by remember { mutableStateOf(false) }
 
     val action = viewModel::onAction
+    val state by viewModel.collectAsState()
 
     viewModel.collectSideEffect {
         when (it) {
@@ -54,7 +57,6 @@ fun AccountSettingScreen(
                 val intent = activityNavigator.navigateToAuth(context)
                 context.startActivity(intent)
             }
-            else -> {}
         }
     }
 
@@ -93,6 +95,10 @@ fun AccountSettingScreen(
             cancelButtonClick = { action(EntireAction.OnSignOutButtonClicked) },
             onDismissRequest = { },
         )
+    }
+
+    if (state.isLoading) {
+        LoadingAnimation()
     }
 }
 

--- a/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/RevokeConfirmScreen.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/RevokeConfirmScreen.kt
@@ -75,6 +75,7 @@ fun RevokeConfirmScreen(
                 intent.putExtra(EXTRA_TOAST_MESSAGE, context.getString(R.string.revoke_done))
                 context.startActivity(intent)
             }
+            else -> { }
         }
     }
 

--- a/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/RevokeConfirmScreen.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/RevokeConfirmScreen.kt
@@ -37,6 +37,7 @@ import com.bff.wespot.entire.viewmodel.EntireViewModel
 import com.bff.wespot.navigation.Navigator
 import com.bff.wespot.navigation.util.EXTRA_TOAST_MESSAGE
 import com.bff.wespot.ui.component.BottomButtonLayout
+import com.bff.wespot.ui.component.LoadingAnimation
 import com.bff.wespot.ui.component.WSBottomSheet
 import com.bff.wespot.ui.component.WSSelectionItem
 import com.bff.wespot.ui.util.handleSideEffect
@@ -169,6 +170,10 @@ fun RevokeConfirmScreen(
             },
             onDismissRequest = { },
         )
+    }
+
+    if (state.isLoading) {
+        LoadingAnimation()
     }
 }
 

--- a/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/RevokeConfirmScreen.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/screen/setting/RevokeConfirmScreen.kt
@@ -75,7 +75,12 @@ fun RevokeConfirmScreen(
                 intent.putExtra(EXTRA_TOAST_MESSAGE, context.getString(R.string.revoke_done))
                 context.startActivity(intent)
             }
-            else -> { }
+
+            is EntireSideEffect.CloseRevokeDialog -> {
+                showDialog = false
+            }
+
+            is EntireSideEffect.CloseSignOutDialog -> { }
         }
     }
 

--- a/feature/entire/src/main/java/com/bff/wespot/entire/state/EntireSideEffect.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/state/EntireSideEffect.kt
@@ -2,4 +2,5 @@ package com.bff.wespot.entire.state
 
 sealed class EntireSideEffect {
     data object NavigateToAuth : EntireSideEffect()
+    data object CloseSignOutDialog : EntireSideEffect()
 }

--- a/feature/entire/src/main/java/com/bff/wespot/entire/state/EntireSideEffect.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/state/EntireSideEffect.kt
@@ -3,4 +3,5 @@ package com.bff.wespot.entire.state
 sealed class EntireSideEffect {
     data object NavigateToAuth : EntireSideEffect()
     data object CloseSignOutDialog : EntireSideEffect()
+    data object CloseRevokeDialog : EntireSideEffect()
 }

--- a/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
@@ -121,6 +121,7 @@ class EntireViewModel @Inject constructor(
     }
 
     private fun handleSignOut() = intent {
+        postSideEffect(EntireSideEffect.CloseSignOutDialog)
         reduce { state.copy(isLoading = true) }
 
         viewModelScope.launch(coroutineDispatcher) {

--- a/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
@@ -119,6 +119,7 @@ class EntireViewModel @Inject constructor(
     }
 
     private fun handleSignOut() = intent {
+        postSideEffect(EntireSideEffect.CloseSignOutDialog)
         reduce { state.copy(isLoading = true) }
 
         viewModelScope.launch(coroutineDispatcher) {

--- a/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
@@ -51,8 +51,8 @@ class EntireViewModel @Inject constructor(
             EntireAction.OnRevokeScreenEntered -> observeProfileDataFlow()
             EntireAction.OnBlockListScreenEntered -> getBlockedMessageList()
             EntireAction.OnRevokeConfirmed -> handleRevokeConfirmed()
-            EntireAction.OnRevokeButtonClicked -> revokeUser()
-            EntireAction.OnSignOutButtonClicked -> signOut()
+            EntireAction.OnRevokeButtonClicked -> handleRevoke()
+            EntireAction.OnSignOutButtonClicked -> handleSignOut()
             EntireAction.UnBlockMessage -> unblockMessage()
             EntireAction.OnInputRevokeReasonSelected -> handleInputRevokeReasonSelected()
             is EntireAction.OnUnBlockButtonClicked -> handleUnBlockButtonClicked(action.messageId)
@@ -93,34 +93,49 @@ class EntireViewModel @Inject constructor(
         reduce { state.copy(webLinkMap = webLinkMap) }
     }
 
-    private fun revokeUser() = intent {
+    private fun handleRevoke() = intent {
+        reduce { state.copy(isLoading = true) }
         val revokeReason = if (state.isInputRevokeReasonSelected) {
             state.revokeReasonList + state.inputRevokeReason
         } else {
             state.revokeReasonList
         }
 
-        viewModelScope.launch {
-            launch {
-                authRepository.revoke(revokeReason)
-                    .onSuccess {
-                        clearCachedData()
-                        postSideEffect(EntireSideEffect.NavigateToAuth)
-                    }
-                    .onNetworkFailure {
-                        postSideEffect(it.toSideEffect())
-                    }
-                    .onFailure {
-                        Timber.e(it)
-                    }
-            }
+        viewModelScope.launch(coroutineDispatcher) {
+            authRepository.revoke(revokeReason)
+                .onSuccess {
+                    KakaoLoginManager.revoke()
+                    clearCachedData()
+                    postSideEffect(EntireSideEffect.NavigateToAuth)
+                }
+                .onNetworkFailure {
+                    postSideEffect(it.toSideEffect())
+                }
+                .onFailure {
+                    reduce { state.copy(isLoading = false) }
+                    Timber.e(it)
+                }
         }
     }
 
-    private fun signOut() = intent {
-        clearCachedData()
-        KakaoLoginManager.logout()
-        postSideEffect(EntireSideEffect.NavigateToAuth)
+    private fun handleSignOut() = intent {
+        reduce { state.copy(isLoading = true) }
+
+        viewModelScope.launch(coroutineDispatcher) {
+            authRepository.signOut()
+                .onSuccess {
+                    KakaoLoginManager.logout()
+                    clearCachedData()
+                    postSideEffect(EntireSideEffect.NavigateToAuth)
+                }
+                .onNetworkFailure {
+                    postSideEffect(it.toSideEffect())
+                }
+                .onFailure {
+                    reduce { state.copy(isLoading = false) }
+                    Timber.e(it)
+                }
+        }
     }
 
     private fun clearCachedData() {

--- a/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
+++ b/feature/entire/src/main/java/com/bff/wespot/entire/viewmodel/EntireViewModel.kt
@@ -94,7 +94,9 @@ class EntireViewModel @Inject constructor(
     }
 
     private fun handleRevoke() = intent {
+        postSideEffect(EntireSideEffect.CloseRevokeDialog)
         reduce { state.copy(isLoading = true) }
+
         val revokeReason = if (state.isInputRevokeReasonSelected) {
             state.revokeReasonList + state.inputRevokeReason
         } else {
@@ -119,7 +121,6 @@ class EntireViewModel @Inject constructor(
     }
 
     private fun handleSignOut() = intent {
-        postSideEffect(EntireSideEffect.CloseSignOutDialog)
         reduce { state.copy(isLoading = true) }
 
         viewModelScope.launch(coroutineDispatcher) {


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#225  : 로그아웃 시에 알림 받지 않도록 수정해요. 

## 2. 🔥 변경된 점

### 1. 로그아웃 API 가 추가되었습니다. 
- 서버에서 토큰을 계속 지니고 있어서, 로그아웃된 이후에도 알림이 오는 이슈가 있었는데요. 
- 이를 서버에서 처리하기로 결정하였고, 로그아웃시, 해당 API를 호출하도록 수정했습니다 .

### 2. 회원탈퇴 로직 수정
- Kakoa SDK UserApiClient 내에 unlink 메소드가 있는 점 확인하였고, 해당 메소드를 저희는 쓰지 않고 있더라고요 ? 
- 해당 메소드는 해당 계정이랑, 카카오 서버랑 연결을 끊기 + logout(토큰 만료)의 기능을 가지고 있고, 탈퇴시에 사용하는 것 같아요. 
- [ 관련 문서 ](https://developers.kakao.com/docs/latest/ko/kakaologin/android#unlink)

### 3. BaseViewModel Channel 
- Channel 내에 Buffered 속성을 추가했습니다 .
- [테드팍 선생님 블로그](https://medium.com/prnd/viewmodel%EC%97%90%EC%84%9C-%EB%8D%94%EC%9D%B4%EC%83%81-eventflow%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EC%A7%80-%EB%A7%88%EC%84%B8%EC%9A%94-3974e8ddffed) 참고했는데요. 해당 속성을 추가하지 않으면, 구독자가 나타날 때까지 다음 이벤트를 호출하지 않아요.
- 해당 속성을 추가하면, 이벤트 버퍼에 이벤트를 추가하고, 다음 이벤트로 넘어가요 !  

### 4. 탈퇴 / 로그아웃 UI  
- 탈퇴 / 로그아웃 API 수정
- 모달내에 버튼 클릭시, 모달을 닫고 로딩 애니메이션 보여주도록 수정 + 실패 시 토스트 노출하도록 수정했습니다.


## 3. ✅ 필수 체크 사항 

## 수정된 회원탈퇴 / 로그아웃 상태에서 정상적으로 동작함을 확인했습니다. 

<img width="859" alt="image" src="https://github.com/user-attachments/assets/48a59ba9-39a1-4a74-a811-586e9e417752" />

## 로그아웃 상태에서 알림 오지 않는 점 확인했습니다. 
- 버전은 1.3.0으로 업데이트하고, 어드민 앱에서 알림 보내면 수신할 수 있는데요 !
- 로그아웃 상태에서는 알림이 오지 않고, 로그인 상태에서는 알림이 오고 있는 점 확인했습니다. 


## 4. 📸 작업물 사진 공유(선택)
### 로그아웃 썡공 
[logout1.webm](https://github.com/user-attachments/assets/1829c4b2-4fb6-4a79-9969-e91fecdc1f94)

### 로그아웃 실패 
[logout_fail.webm](https://github.com/user-attachments/assets/b9b0c268-d550-487a-9fce-6ba9d9bfdd54)


## 5. 💡알게된 혹은 궁금한 사항
