### PR TITLE
#272: 게시글 상세 화면 UI 구축

### DIFF
--- a/app/src/main/kotlin/com/bff/wespot/navigation/navigator/NavigatorImpl.kt
+++ b/app/src/main/kotlin/com/bff/wespot/navigation/navigator/NavigatorImpl.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.net.Uri
 import com.bff.wespot.BuildConfig
 import com.bff.wespot.auth.AuthActivity
+import com.bff.wespot.community.detail.PostDetailActivity
 import com.bff.wespot.community.write.WritePostActivity
 import com.bff.wespot.main.MainActivity
 import com.bff.wespot.navigation.Navigator
@@ -199,6 +200,12 @@ class NavigatorImpl @Inject constructor() : Navigator {
 
     override fun navigateToWriteActivity(context: Context): Intent {
         val intent = context.buildIntent<WritePostActivity>()
+        return intent
+    }
+
+    override fun navigateToPostDetailActivity(context: Context, postId: String): Intent {
+        val intent = context.buildIntent<PostDetailActivity>()
+        intent.putExtra("postId", postId)
         return intent
     }
 }

--- a/core/model/src/main/kotlin/com/bff/wespot/model/community/PostComment.kt
+++ b/core/model/src/main/kotlin/com/bff/wespot/model/community/PostComment.kt
@@ -1,0 +1,10 @@
+package com.bff.wespot.model.community
+
+data class PostComment(
+    val isMe: Boolean,
+    val nickname: String,
+    val profileImage: String,
+    val message: String,
+    val createdAt: String,
+    val likeCount: Int,
+)

--- a/core/model/src/main/kotlin/com/bff/wespot/model/community/PostDetail.kt
+++ b/core/model/src/main/kotlin/com/bff/wespot/model/community/PostDetail.kt
@@ -1,0 +1,77 @@
+package com.bff.wespot.model.community
+
+import com.bff.wespot.model.serverDriven.type.IconType
+import com.bff.wespot.model.serverDriven.type.ImageType
+import com.bff.wespot.model.serverDriven.type.RichTextType
+
+data class PostDetail(
+    val id: String,
+    val content: PostDetailContent,
+) {
+    data class PostDetailContent(
+        val category: Category,
+        val headerSection: HeaderSection,
+        val infoSection: InfoSection,
+        val contentSection: ContentSection?,
+        val footerSection: FooterSection,
+    ) {
+        data class Category(
+            val text: RichTextType,
+            val target: String,
+            val icon: IconType,
+        )
+
+        data class HeaderSection(
+            val profileImage: String,
+            val nickname: RichTextType,
+            val createdAt: RichTextType,
+            val button: Button,
+        ) {
+            data class Button(
+                val type: String,
+                val icon: IconType,
+                val text: RichTextType,
+            )
+        }
+
+        data class InfoSection(
+            val title: RichTextType,
+            val description: RichTextType,
+            val maxLine: Int,
+        )
+
+        sealed class ContentSection {
+            data class ImagesContent(
+                val content: List<ImageType>,
+            ) : ContentSection()
+        }
+
+        data class FooterSection(
+            val reactions: List<Reaction>,
+            val scrap: Scrap,
+        ) {
+            sealed class Reaction(
+                open val icon: IconType,
+                open val count: RichTextType,
+                open val selected: Boolean,
+            ) {
+                data class Chat(
+                    override val icon: IconType,
+                    override val count: RichTextType,
+                    override val selected: Boolean,
+                ) : Reaction(icon, count, selected)
+
+                data class Like(
+                    override val icon: IconType,
+                    override val count: RichTextType,
+                    override val selected: Boolean,
+                ) : Reaction(icon, count, selected)
+            }
+
+            data class Scrap(
+                val icon: IconType,
+                val count: RichTextType,
+            )
+        }
+    }
+}

--- a/core/navigation/src/main/kotlin/com/bff/wespot/navigation/Navigator.kt
+++ b/core/navigation/src/main/kotlin/com/bff/wespot/navigation/Navigator.kt
@@ -42,4 +42,6 @@ interface Navigator {
     fun navigateToWebLink(context: Context, webLink: String)
 
     fun navigateToWriteActivity(context: Context): Intent
+
+    fun navigateToPostDetailActivity(context: Context, postId: String): Intent
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/di/DataRemoteModule.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/di/DataRemoteModule.kt
@@ -8,6 +8,8 @@ import com.bff.wespot.data.remote.source.auth.AuthDataSource
 import com.bff.wespot.data.remote.source.auth.AuthDataSourceImpl
 import com.bff.wespot.data.remote.source.community.CommunityDataSource
 import com.bff.wespot.data.remote.source.community.CommunityDataSourceImpl
+import com.bff.wespot.data.remote.source.community.PostDetailDataSource
+import com.bff.wespot.data.remote.source.community.PostDetailDataSourceImpl
 import com.bff.wespot.data.remote.source.community.WritePostDataSource
 import com.bff.wespot.data.remote.source.community.WritePostDataSourceImpl
 import com.bff.wespot.data.remote.source.firebase.config.RemoteConfigDataSource
@@ -120,4 +122,10 @@ abstract class DataRemoteModule {
     abstract fun bindsWritePostDataSource(
         writePostDataSourceImpl: WritePostDataSourceImpl
     ): WritePostDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsPostDetailDataSource(
+        postDetailDataSourceImpl: PostDetailDataSourceImpl
+    ): PostDetailDataSource
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/model/community/PostCommentDto.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/model/community/PostCommentDto.kt
@@ -1,0 +1,25 @@
+package com.bff.wespot.data.remote.model.community
+
+import com.bff.wespot.model.community.PostComment
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PostCommentDto(
+    val isMe: Boolean,
+    val nickname: String,
+    val profileImage: String,
+    val message: String,
+    val createdAt: String,
+    val likeCount: Int,
+) {
+    fun toDomain(): PostComment {
+        return PostComment(
+            isMe = isMe,
+            nickname = nickname,
+            profileImage = profileImage,
+            message = message,
+            createdAt = createdAt,
+            likeCount = likeCount,
+        )
+    }
+}

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/model/community/PostDetailDto.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/model/community/PostDetailDto.kt
@@ -1,0 +1,185 @@
+package com.bff.wespot.data.remote.model.community
+
+import com.bff.wespot.data.remote.model.serverDriven.type.IconTypeDto
+import com.bff.wespot.data.remote.model.serverDriven.type.ImageTypeDto
+import com.bff.wespot.data.remote.model.serverDriven.type.RichTextTypeDto
+import com.bff.wespot.model.community.PostDetail
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PostDetailDto(
+    val id: String,
+    val content: PostDetailContentDto,
+) {
+    @Serializable
+    data class PostDetailContentDto(
+        val category: CategoryDto,
+        val headerSection: HeaderSectionDto,
+        val infoSection: InfoSectionDto,
+        val contentSection: ContentSectionDto? = null,
+        val footerSection: FooterSectionDto,
+    ) {
+        @Serializable
+        data class CategoryDto(
+            val text: RichTextTypeDto,
+            val target: String,
+            val icon: IconTypeDto,
+        )
+
+        @Serializable
+        data class HeaderSectionDto(
+            val profileImage: String,
+            val nickname: RichTextTypeDto,
+            val createdAt: RichTextTypeDto,
+            val button: ButtonDto,
+        ) {
+            @Serializable
+            data class ButtonDto(
+                val type: String,
+                val icon: IconTypeDto,
+                val text: RichTextTypeDto,
+            )
+        }
+
+        @Serializable
+        data class InfoSectionDto(
+            val title: RichTextTypeDto,
+            val description: RichTextTypeDto,
+            val maxLine: Int,
+        )
+
+        @Serializable
+        sealed class ContentSectionDto {
+            @Serializable
+            @SerialName("Images")
+            data class ImagesContentDto(
+                val content: List<ImageTypeDto>,
+            ) : ContentSectionDto()
+        }
+
+        @Serializable
+        data class FooterSectionDto(
+            val reactions: List<ReactionDto>,
+            val scrap: ScrapDto,
+        ) {
+            @Serializable
+            sealed class ReactionDto {
+                abstract val icon: IconTypeDto
+                abstract val count: RichTextTypeDto
+                abstract val selected: Boolean
+
+                @Serializable
+                @SerialName("Chat")
+                data class ChatDto(
+                    override val icon: IconTypeDto,
+                    override val count: RichTextTypeDto,
+                    override val selected: Boolean
+                ) : ReactionDto()
+
+                @Serializable
+                @SerialName("Like")
+                data class LikeDto(
+                    override val icon: IconTypeDto,
+                    override val count: RichTextTypeDto,
+                    override val selected: Boolean
+                ) : ReactionDto()
+            }
+
+            @Serializable
+            data class ScrapDto(
+                val icon: IconTypeDto,
+                val count: RichTextTypeDto,
+            )
+        }
+    }
+
+    fun toDomain(): PostDetail {
+        return PostDetail(
+            id = id,
+            content = content.toDomain(),
+        )
+    }
+}
+
+private fun PostDetailDto.PostDetailContentDto.toDomain() = PostDetail.PostDetailContent(
+    category = category.toDomain(),
+    headerSection = headerSection.toDomain(),
+    infoSection = infoSection.toDomain(),
+    contentSection = contentSection?.toDomain(),
+    footerSection = footerSection.toDomain(),
+)
+
+
+private fun PostDetailDto.PostDetailContentDto.CategoryDto.toDomain() =
+    PostDetail.PostDetailContent.Category(
+        text = text.toDomain(),
+        target = target,
+        icon = icon.toDomain(),
+    )
+
+private fun PostDetailDto.PostDetailContentDto.HeaderSectionDto.toDomain() =
+    PostDetail.PostDetailContent.HeaderSection(
+        profileImage = profileImage,
+        nickname = nickname.toDomain(),
+        createdAt = createdAt.toDomain(),
+        button = button.toDomain(),
+    )
+
+private fun PostDetailDto.PostDetailContentDto.HeaderSectionDto.ButtonDto.toDomain() =
+    PostDetail.PostDetailContent.HeaderSection.Button(
+        type = type,
+        icon = icon.toDomain(),
+        text = text.toDomain(),
+    )
+
+private fun PostDetailDto.PostDetailContentDto.InfoSectionDto.toDomain() =
+    PostDetail.PostDetailContent.InfoSection(
+        title = title.toDomain(),
+        description = description.toDomain(),
+        maxLine = maxLine,
+    )
+
+private fun PostDetailDto.PostDetailContentDto.ContentSectionDto.toDomain(): PostDetail.PostDetailContent.ContentSection =
+    when (this) {
+        is PostDetailDto.PostDetailContentDto.ContentSectionDto.ImagesContentDto -> {
+            this.toDomain()
+        }
+    }
+
+private fun PostDetailDto.PostDetailContentDto.ContentSectionDto.ImagesContentDto.toDomain() =
+    PostDetail.PostDetailContent.ContentSection.ImagesContent(
+        content = content.map { it.toDomain() }
+    )
+
+private fun PostDetailDto.PostDetailContentDto.FooterSectionDto.toDomain() =
+    PostDetail.PostDetailContent.FooterSection(
+        reactions = reactions.map { it.toDomain() },
+        scrap = scrap.toDomain(),
+    )
+
+private fun PostDetailDto.PostDetailContentDto.FooterSectionDto.ReactionDto.toDomain() =
+    when (this) {
+        is PostDetailDto.PostDetailContentDto.FooterSectionDto.ReactionDto.ChatDto -> {
+            PostDetail.PostDetailContent.FooterSection.Reaction.Chat(
+                icon = icon.toDomain(),
+                count = count.toDomain(),
+                selected = selected
+            )
+        }
+
+        is PostDetailDto.PostDetailContentDto.FooterSectionDto.ReactionDto.LikeDto -> {
+            PostDetail.PostDetailContent.FooterSection.Reaction.Like(
+                icon = icon.toDomain(),
+                count = count.toDomain(),
+                selected = selected
+            )
+        }
+    }
+
+private fun PostDetailDto.PostDetailContentDto.FooterSectionDto.ScrapDto.toDomain(): PostDetail.PostDetailContent.FooterSection.Scrap {
+    return PostDetail.PostDetailContent.FooterSection.Scrap(
+        icon = icon.toDomain(),
+        count = count.toDomain(),
+    )
+}

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/community/PostDetailDataSource.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/community/PostDetailDataSource.kt
@@ -1,0 +1,9 @@
+package com.bff.wespot.data.remote.source.community
+
+import com.bff.wespot.data.remote.model.community.PostCommentDto
+import com.bff.wespot.data.remote.model.community.PostDetailDto
+
+interface PostDetailDataSource {
+    suspend fun getPostDetail(postId: String): Result<PostDetailDto>
+    suspend fun getPostComments(postId: String): Result<List<PostCommentDto>>
+}

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/community/PostDetailDataSourceImpl.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/community/PostDetailDataSourceImpl.kt
@@ -1,0 +1,32 @@
+package com.bff.wespot.data.remote.source.community
+
+import com.bff.wespot.data.remote.model.community.PostCommentDto
+import com.bff.wespot.data.remote.model.community.PostDetailDto
+import com.bff.wespot.network.extensions.safeRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.request.parameter
+import io.ktor.http.HttpMethod
+import io.ktor.http.path
+import javax.inject.Inject
+
+class PostDetailDataSourceImpl @Inject constructor(
+    private val httpClient: HttpClient
+) : PostDetailDataSource {
+    override suspend fun getPostDetail(postId: String): Result<PostDetailDto> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("api/v1/post/$postId")
+                parameter("postId", postId)
+            }
+        }
+
+    override suspend fun getPostComments(postId: String): Result<List<PostCommentDto>> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("api/v1/post/comment")
+                parameter("postId", postId)
+            }
+        }
+}

--- a/data/src/main/kotlin/com/bff/wespot/data/di/DataModule.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/di/DataModule.kt
@@ -4,6 +4,7 @@ import com.bff.wespot.data.repository.CommonRepositoryImpl
 import com.bff.wespot.data.repository.DataStoreRepositoryImpl
 import com.bff.wespot.data.repository.auth.AuthRepositoryImpl
 import com.bff.wespot.data.repository.community.CommunityRepositoryImpl
+import com.bff.wespot.data.repository.community.PostDetailRepositoryImpl
 import com.bff.wespot.data.repository.community.WritePostRepositoryImpl
 import com.bff.wespot.data.repository.firebase.config.RemoteConfigRepositoryImpl
 import com.bff.wespot.data.repository.firebase.messaging.MessagingRepositoryImpl
@@ -19,6 +20,7 @@ import com.bff.wespot.domain.repository.CommonRepository
 import com.bff.wespot.domain.repository.DataStoreRepository
 import com.bff.wespot.domain.repository.auth.AuthRepository
 import com.bff.wespot.domain.repository.community.CommunityRepository
+import com.bff.wespot.domain.repository.community.PostDetailRepository
 import com.bff.wespot.domain.repository.community.WritePostRepository
 import com.bff.wespot.domain.repository.firebase.config.RemoteConfigRepository
 import com.bff.wespot.domain.repository.firebase.messaging.MessagingRepository
@@ -128,4 +130,10 @@ abstract class DataModule {
     abstract fun bindsWritePostRepository(
         writePostRepositoryImpl: WritePostRepositoryImpl
     ): WritePostRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsPostDetailRepository(
+        postDetailRepositoryImpl: PostDetailRepositoryImpl
+    ): PostDetailRepository
 }

--- a/data/src/main/kotlin/com/bff/wespot/data/repository/community/PostDetailRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/repository/community/PostDetailRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.bff.wespot.data.repository.community
+
+import com.bff.wespot.data.remote.source.community.PostDetailDataSource
+import com.bff.wespot.domain.repository.community.PostDetailRepository
+import com.bff.wespot.model.community.PostComment
+import com.bff.wespot.model.community.PostDetail
+import javax.inject.Inject
+
+class PostDetailRepositoryImpl @Inject constructor(
+    private val postDetailDataSource: PostDetailDataSource
+) : PostDetailRepository {
+    override suspend fun getPostDetail(postId: String): Result<PostDetail> =
+        postDetailDataSource.getPostDetail(postId)
+            .mapCatching {
+                it.toDomain()
+            }
+
+    override suspend fun getPostComments(postId: String): Result<List<PostComment>> =
+        postDetailDataSource.getPostComments(postId)
+            .mapCatching {
+                it.map { it.toDomain() }
+            }
+}

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/community/PostDetailRepository.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/community/PostDetailRepository.kt
@@ -1,0 +1,9 @@
+package com.bff.wespot.domain.repository.community
+
+import com.bff.wespot.model.community.PostComment
+import com.bff.wespot.model.community.PostDetail
+
+interface PostDetailRepository {
+    suspend fun getPostDetail(postId: String): Result<PostDetail>
+    suspend fun getPostComments(postId: String): Result<List<PostComment>>
+}

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/component/PostItem.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/component/PostItem.kt
@@ -42,10 +42,17 @@ import com.bff.wespot.model.serverDriven.type.ImageType
 import com.bff.wespot.model.serverDriven.type.RichTextType
 import com.bff.wespot.server.driven.type.Icon
 import com.bff.wespot.server.driven.type.Text
+import com.bff.wespot.ui.util.clickableSingle
 
 @Composable
-internal fun PostContentUiModel.Item() {
-    Column {
+internal fun PostContentUiModel.Item(
+    navigateToPost: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.clickableSingle {
+            navigateToPost.invoke()
+        },
+    ) {
         HorizontalDivider(color = WeSpotThemeManager.colors.bottomSheetColor)
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -399,7 +406,7 @@ private object PostItemPreviewData {
 private fun PostItemPreview() {
     WeSpotTheme {
         Surface {
-            PostItemPreviewData.samplePostItem.content.Item()
+            PostItemPreviewData.samplePostItem.content.Item({})
         }
     }
 }
@@ -409,7 +416,7 @@ private fun PostItemPreview() {
 private fun PostItemEmptyPreview() {
     WeSpotTheme {
         Surface {
-            PostItemPreviewData.samplePostItemEmpty.content.Item()
+            PostItemPreviewData.samplePostItemEmpty.content.Item({})
         }
     }
 }

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/PostDetailActivity.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/PostDetailActivity.kt
@@ -1,0 +1,27 @@
+package com.bff.wespot.community.detail
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.runtime.getValue
+import com.bff.wespot.community.detail.screen.PostDetailScreen
+import dagger.hilt.android.AndroidEntryPoint
+import org.orbitmvi.orbit.compose.collectAsState
+
+@AndroidEntryPoint
+class PostDetailActivity : ComponentActivity() {
+    private val viewModel: PostDetailViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            val state by viewModel.collectAsState()
+            PostDetailScreen(
+                uiModel = state.detail.content,
+                comments = state.comments,
+            )
+        }
+    }
+}

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/PostDetailViewModel.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/PostDetailViewModel.kt
@@ -29,31 +29,33 @@ class PostDetailViewModel @Inject constructor(
 
     init {
         viewModelScope.launch(coroutineDispatcher) {
-            postDetailRepository.getPostDetail(postId = param.postId)
-                .onNetworkFailure {
-                    postSideEffect(it.toSideEffect())
-                }
-                .onSuccess {
-                    intent {
-                        reduce {
-                            state.copy(detail = it.toUiModel())
+            launch {
+                postDetailRepository.getPostDetail(postId = param.postId)
+                    .onNetworkFailure {
+                        postSideEffect(it.toSideEffect())
+                    }
+                    .onSuccess {
+                        intent {
+                            reduce {
+                                state.copy(detail = it.toUiModel())
+                            }
                         }
                     }
-                }
-        }
+            }
 
-        viewModelScope.launch(coroutineDispatcher) {
-            postDetailRepository.getPostComments(param.postId)
-                .onNetworkFailure {
-                    postSideEffect(it.toSideEffect())
-                }
-                .onSuccess {
-                    intent {
-                        reduce {
-                            state.copy(comments = it.map { it.toUiModel() })
+            launch {
+                postDetailRepository.getPostComments(param.postId)
+                    .onNetworkFailure {
+                        postSideEffect(it.toSideEffect())
+                    }
+                    .onSuccess {
+                        intent {
+                            reduce {
+                                state.copy(comments = it.map { it.toUiModel() })
+                            }
                         }
                     }
-                }
+            }
         }
     }
 }

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/PostDetailViewModel.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/PostDetailViewModel.kt
@@ -1,0 +1,59 @@
+package com.bff.wespot.community.detail
+
+import androidx.lifecycle.viewModelScope
+import com.bff.wespot.common.extension.onNetworkFailure
+import com.bff.wespot.community.detail.state.PostDetailParams
+import com.bff.wespot.community.detail.state.PostDetailSideEffect
+import com.bff.wespot.community.detail.state.PostDetailUiState
+import com.bff.wespot.community.uimodel.PostCommentUiModel.Companion.toUiModel
+import com.bff.wespot.community.uimodel.PostDetailUiModel.Companion.toUiModel
+import com.bff.wespot.domain.repository.community.PostDetailRepository
+import com.bff.wespot.ui.base.BaseViewModel
+import com.bff.wespot.ui.model.SideEffect.Companion.toSideEffect
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class PostDetailViewModel @Inject constructor(
+    param: PostDetailParams,
+    private val postDetailRepository: PostDetailRepository,
+) : BaseViewModel(), ContainerHost<PostDetailUiState, PostDetailSideEffect> {
+    override val container = container<PostDetailUiState, PostDetailSideEffect>(
+        PostDetailUiState(),
+    )
+
+    init {
+        viewModelScope.launch(coroutineDispatcher) {
+            postDetailRepository.getPostDetail(postId = param.postId)
+                .onNetworkFailure {
+                    postSideEffect(it.toSideEffect())
+                }
+                .onSuccess {
+                    intent {
+                        reduce {
+                            state.copy(detail = it.toUiModel())
+                        }
+                    }
+                }
+        }
+
+        viewModelScope.launch(coroutineDispatcher) {
+            postDetailRepository.getPostComments(param.postId)
+                .onNetworkFailure {
+                    postSideEffect(it.toSideEffect())
+                }
+                .onSuccess {
+                    intent {
+                        reduce {
+                            state.copy(comments = it.map { it.toUiModel() })
+                        }
+                    }
+                }
+        }
+    }
+}

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/screen/PostDetailScreen.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/screen/PostDetailScreen.kt
@@ -15,12 +15,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -106,48 +105,54 @@ internal fun PostDetailScreen(
             )
         },
     ) { paddingValues ->
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
-                .verticalScroll(rememberScrollState()),
+                .padding(paddingValues),
         ) {
-            Column {
-                HorizontalDivider(color = WeSpotThemeManager.colors.bottomSheetColor)
+            item {
+                Column {
+                    HorizontalDivider(color = WeSpotThemeManager.colors.bottomSheetColor)
 
-                Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = Modifier.height(24.dp))
 
-                Column(
-                    modifier = Modifier.padding(horizontal = 20.dp),
-                ) {
-                    uiModel.category.Item(onCategoryClick)
+                    Column(
+                        modifier = Modifier.padding(horizontal = 20.dp),
+                    ) {
+                        uiModel.category.Item(onCategoryClick)
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                        Spacer(modifier = Modifier.height(16.dp))
 
-                    uiModel.headerSection.Item(onProfileClick, onNotificationClick)
+                        uiModel.headerSection.Item(onProfileClick, onNotificationClick)
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                        Spacer(modifier = Modifier.height(16.dp))
 
-                    uiModel.infoSection.Item()
+                        uiModel.infoSection.Item()
 
-                    uiModel.contentSection?.let {
-                        Spacer(modifier = Modifier.height(24.dp))
-                        it.Item()
+                        uiModel.contentSection?.let {
+                            Spacer(modifier = Modifier.height(24.dp))
+                            it.Item()
+                        }
+
+                        Spacer(modifier = Modifier.height(20.dp))
+
+                        uiModel.footerSection.Item(onReactionClick, onScrapClick)
+
+                        Spacer(modifier = Modifier.height(16.dp))
                     }
 
-                    Spacer(modifier = Modifier.height(20.dp))
-
-                    uiModel.footerSection.Item(onReactionClick, onScrapClick)
-
-                    Spacer(modifier = Modifier.height(16.dp))
+                    HorizontalDivider(
+                        thickness = 8.dp,
+                        color = Gray700,
+                    )
                 }
+            }
 
-                HorizontalDivider(
-                    thickness = 8.dp,
-                    color = Gray700,
-                )
-
-                comments.Item()
+            items(comments) {
+                it.Item()
+                if (it != comments.last()) {
+                    Spacer(modifier = Modifier.height(20.dp))
+                }
             }
         }
     }
@@ -217,7 +222,10 @@ private fun PostDetailContentUiModel.HeaderSectionUiModel.Item(
         Box(
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
-                .background(WeSpotThemeManager.colors.cardBackgroundColor, RoundedCornerShape(8.dp)),
+                .background(
+                    WeSpotThemeManager.colors.cardBackgroundColor,
+                    RoundedCornerShape(8.dp)
+                ),
         ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -320,17 +328,6 @@ private fun PostDetailContentUiModel.FooterSectionUiModel.Item(
         ) {
             scrap.icon.Icon(modifier = Modifier.size(18.dp))
             scrap.count.Text(StaticTypeScale.Default.body6)
-        }
-    }
-}
-
-@Composable
-private fun List<PostCommentUiModel>.Item() {
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(20.dp),
-    ) {
-        items(this@Item) {
-            it.Item()
         }
     }
 }
@@ -443,40 +440,6 @@ private fun PostCommentUiModel.Item() {
     }
 }
 
-@Preview
-@Composable
-private fun CommentsPreview() {
-    WeSpotTheme {
-        val sampleComment = listOf(
-            PostCommentUiModel(
-                isMe = true,
-                nickname = "김개발자",
-                profileImage = "https://via.placeholder.com/32",
-                message = "정말 유용한 정보네요! React 18의 Concurrent Features에 대해 잘 이해하게 되었습니다.",
-                createdAt = "2024년 1월 15일 15:00",
-                likeCount = 5,
-            ),
-            PostCommentUiModel(
-                isMe = false,
-                nickname = "김개발자",
-                profileImage = "https://via.placeholder.com/32",
-                message = "정말 유용한 정보네요! React 18의 Concurrent Features에 대해 잘 이해하게 되었습니다.",
-                createdAt = "2024년 1월 15일 15:00",
-                likeCount = 5,
-            ),
-        )
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(WeSpotThemeManager.colors.backgroundColor)
-                .padding(16.dp),
-        ) {
-            sampleComment.Item()
-        }
-    }
-}
-
 private object PostDetailPreviewData {
     val samplePostDetail = PostDetailUiModel(
         id = "post_detail_1",
@@ -526,8 +489,8 @@ private object PostDetailPreviewData {
                 ),
                 description = RichTextType(
                     text = "React 18에서 도입된 Concurrent Features는 사용자 경험을 크게 개선할 수 있는 강력한 기능들입니다. " +
-                        "이번 포스트에서는 Suspense, useTransition, useDeferredValue 등의 새로운 기능들을 실제 예제와 함께 자세히 살펴보겠습니다. " +
-                        "각 기능의 사용법부터 실무에서의 활용 방안까지 포괄적으로 다루어보겠습니다.",
+                            "이번 포스트에서는 Suspense, useTransition, useDeferredValue 등의 새로운 기능들을 실제 예제와 함께 자세히 살펴보겠습니다. " +
+                            "각 기능의 사용법부터 실무에서의 활용 방안까지 포괄적으로 다루어보겠습니다.",
                     color = ColorType.Token("white"),
                     typography = "body6",
                 ),
@@ -593,10 +556,28 @@ private object PostDetailPreviewData {
 @Preview(showBackground = true)
 @Composable
 private fun PostDetailScreenPreview() {
+    val sampleComment = listOf(
+        PostCommentUiModel(
+            isMe = true,
+            nickname = "김개발자",
+            profileImage = "https://via.placeholder.com/32",
+            message = "정말 유용한 정보네요! React 18의 Concurrent Features에 대해 잘 이해하게 되었습니다.",
+            createdAt = "2024년 1월 15일 15:00",
+            likeCount = 5,
+        ),
+        PostCommentUiModel(
+            isMe = false,
+            nickname = "김개발자",
+            profileImage = "https://via.placeholder.com/32",
+            message = "정말 유용한 정보네요! React 18의 Concurrent Features에 대해 잘 이해하게 되었습니다.",
+            createdAt = "2024년 1월 15일 15:00",
+            likeCount = 5,
+        ),
+    )
     WeSpotTheme {
         PostDetailScreen(
             uiModel = PostDetailPreviewData.samplePostDetail.content,
-            comments = emptyList(),
+            comments = sampleComment,
         )
     }
 }

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/screen/PostDetailScreen.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/screen/PostDetailScreen.kt
@@ -1,0 +1,602 @@
+package com.bff.wespot.community.detail.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.compose.rememberAsyncImagePainter
+import com.bff.wespot.community.presentation.R
+import com.bff.wespot.community.uimodel.PostCommentUiModel
+import com.bff.wespot.community.uimodel.PostDetailUiModel
+import com.bff.wespot.community.uimodel.PostDetailUiModel.PostDetailContentUiModel
+import com.bff.wespot.designsystem.component.header.WSTopBar
+import com.bff.wespot.designsystem.theme.Gray200
+import com.bff.wespot.designsystem.theme.Gray300
+import com.bff.wespot.designsystem.theme.Gray400
+import com.bff.wespot.designsystem.theme.Gray600
+import com.bff.wespot.designsystem.theme.Gray700
+import com.bff.wespot.designsystem.theme.StaticTypeScale
+import com.bff.wespot.designsystem.theme.WeSpotTheme
+import com.bff.wespot.designsystem.theme.WeSpotThemeManager
+import com.bff.wespot.designsystem.theme.White
+import com.bff.wespot.model.serverDriven.type.ColorType
+import com.bff.wespot.model.serverDriven.type.IconType
+import com.bff.wespot.model.serverDriven.type.ImageType
+import com.bff.wespot.model.serverDriven.type.RichTextType
+import com.bff.wespot.server.driven.type.Icon
+import com.bff.wespot.server.driven.type.Text
+import com.bff.wespot.ui.util.clickableSingle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun PostDetailScreen(
+    uiModel: PostDetailContentUiModel,
+    comments: List<PostCommentUiModel>,
+    onBackClick: () -> Unit = { },
+    onCategoryClick: (String) -> Unit = { },
+    onProfileClick: (String) -> Unit = { },
+    onNotificationClick: () -> Unit = { },
+    onReactionClick: (String) -> Unit = { },
+    onScrapClick: () -> Unit = { },
+) {
+    Scaffold(
+        topBar = {
+            WSTopBar(
+                titleContent = {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        uiModel.category.text.Text(StaticTypeScale.Default.body6)
+
+                        Box(
+                            modifier = Modifier
+                                .clip(CircleShape)
+                                .background(
+                                    WeSpotThemeManager.colors.cardBackgroundColor,
+                                    CircleShape,
+                                ),
+                        ) {
+                            uiModel.category.icon.Icon()
+                        }
+                    }
+                },
+                title = "",
+                canNavigateBack = true,
+                navigateUp = {
+                    onBackClick.invoke()
+                },
+                action = {
+                    Icon(
+                        painter = rememberAsyncImagePainter(R.drawable.horizontal_3dot),
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 16.dp),
+                    )
+                },
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Column {
+                HorizontalDivider(color = WeSpotThemeManager.colors.bottomSheetColor)
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Column(
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                ) {
+                    uiModel.category.Item(onCategoryClick)
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    uiModel.headerSection.Item(onProfileClick, onNotificationClick)
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    uiModel.infoSection.Item()
+
+                    uiModel.contentSection?.let {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        it.Item()
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    uiModel.footerSection.Item(onReactionClick, onScrapClick)
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+
+                HorizontalDivider(
+                    thickness = 8.dp,
+                    color = Gray700,
+                )
+
+                comments.Item()
+            }
+        }
+    }
+}
+
+@Composable
+private fun PostDetailContentUiModel.CategoryUiModel.Item(
+    onCategoryClick: (String) -> Unit,
+) {
+    Row(
+        modifier = Modifier.clickableSingle { onCategoryClick(target) },
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        text.Text(StaticTypeScale.Default.badge)
+        icon.Icon(modifier = Modifier.size(16.dp))
+    }
+}
+
+@Composable
+private fun PostDetailContentUiModel.HeaderSectionUiModel.Item(
+    onProfileClick: (String) -> Unit,
+    onNotificationClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .background(White, CircleShape)
+                    .clickableSingle { onProfileClick(profileImage) },
+            ) {
+                AsyncImage(
+                    model = profileImage,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                )
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                nickname.Text(StaticTypeScale.Default.body3)
+                createdAt.Text(StaticTypeScale.Default.body8)
+            }
+
+            Row(
+                modifier = Modifier.clickableSingle { onNotificationClick() },
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                button.icon.Icon(modifier = Modifier.size(16.dp))
+                button.text.Text(StaticTypeScale.Default.body7)
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .background(WeSpotThemeManager.colors.cardBackgroundColor, RoundedCornerShape(8.dp)),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                button.icon.Icon(
+                    modifier = Modifier.size(15.dp),
+                )
+
+                button.text.Text(StaticTypeScale.Default.body9)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PostDetailContentUiModel.InfoSectionUiModel.Item() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        title.Text(
+            textStyle = StaticTypeScale.Default.header3,
+            maxLines = 1,
+        )
+
+        description.Text(
+            textStyle = StaticTypeScale.Default.body6,
+            maxLines = if (maxLine == 0) Int.MAX_VALUE else maxLine,
+        )
+    }
+}
+
+@Composable
+private fun PostDetailContentUiModel.ContentSectionUiModel.Item() {
+    when (this) {
+        is PostDetailContentUiModel.ContentSectionUiModel.ImagesContentUiModel -> {
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(content) { image ->
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(12.dp))
+                            .width(image.width.dp)
+                            .height(image.height.dp)
+                            .background(White, RoundedCornerShape(12.dp)),
+                    ) {
+                        AsyncImage(
+                            model = image.url,
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(12.dp))
+                                .width(image.width.dp)
+                                .height(image.height.dp),
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PostDetailContentUiModel.FooterSectionUiModel.Item(
+    onReactionClick: (String) -> Unit,
+    onScrapClick: () -> Unit,
+) {
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            reactions.forEach { reaction ->
+                Row(
+                    modifier = Modifier.clickableSingle {
+                        onReactionClick(
+                            when (reaction) {
+                                is PostDetailContentUiModel.FooterSectionUiModel.ReactionUiModel.ChatUiModel -> "chat"
+                                is PostDetailContentUiModel.FooterSectionUiModel.ReactionUiModel.LikeUiModel -> "like"
+                            },
+                        )
+                    },
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    reaction.icon.Icon(modifier = Modifier.size(18.dp))
+                    reaction.count.Text(StaticTypeScale.Default.body6)
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier.clickableSingle { onScrapClick() },
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            scrap.icon.Icon(modifier = Modifier.size(18.dp))
+            scrap.count.Text(StaticTypeScale.Default.body6)
+        }
+    }
+}
+
+@Composable
+private fun List<PostCommentUiModel>.Item() {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        items(this@Item) {
+            it.Item()
+        }
+    }
+}
+
+@Composable
+private fun PostCommentUiModel.Item() {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = if (isMe) {
+            Alignment.End
+        } else {
+            Alignment.Start
+        },
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (!isMe) {
+                Box(
+                    modifier = Modifier
+                        .background(Gray300, CircleShape),
+                ) {
+                    AsyncImage(
+                        model = profileImage,
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape),
+                        contentDescription = null,
+                    )
+                }
+            }
+
+            Column(
+                horizontalAlignment = if (isMe) {
+                    Alignment.End
+                } else {
+                    Alignment.Start
+                },
+            ) {
+                Text(
+                    text = nickname,
+                    color = Gray200,
+                    style = StaticTypeScale.Default.body8,
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Start,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(Gray600, RoundedCornerShape(16.dp)),
+                    ) {
+                        Text(
+                            text = message,
+                            style = StaticTypeScale.Default.body6,
+                            color = White,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(10.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = createdAt,
+                        style = StaticTypeScale.Default.body9,
+                        color = Gray400,
+                    )
+
+                    Icon(
+                        painter = rememberAsyncImagePainter(R.drawable.like),
+                        contentDescription = null,
+                        tint = Gray400,
+                        modifier = Modifier.size(12.dp),
+                    )
+
+                    Text(
+                        text = likeCount.toString(),
+                        style = StaticTypeScale.Default.body9,
+                        color = Gray400,
+                    )
+
+                    Text(
+                        text = "•",
+                        style = StaticTypeScale.Default.body9,
+                        color = Gray400,
+                    )
+
+                    if (isMe) {
+                        Text(
+                            text = stringResource(R.string.postdetail_delete),
+                            style = StaticTypeScale.Default.body9,
+                            color = Gray400,
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(R.string.postdetail_report),
+                            style = StaticTypeScale.Default.body9,
+                            color = Gray400,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CommentsPreview() {
+    WeSpotTheme {
+        val sampleComment = listOf(
+            PostCommentUiModel(
+                isMe = true,
+                nickname = "김개발자",
+                profileImage = "https://via.placeholder.com/32",
+                message = "정말 유용한 정보네요! React 18의 Concurrent Features에 대해 잘 이해하게 되었습니다.",
+                createdAt = "2024년 1월 15일 15:00",
+                likeCount = 5,
+            ),
+            PostCommentUiModel(
+                isMe = false,
+                nickname = "김개발자",
+                profileImage = "https://via.placeholder.com/32",
+                message = "정말 유용한 정보네요! React 18의 Concurrent Features에 대해 잘 이해하게 되었습니다.",
+                createdAt = "2024년 1월 15일 15:00",
+                likeCount = 5,
+            ),
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(WeSpotThemeManager.colors.backgroundColor)
+                .padding(16.dp),
+        ) {
+            sampleComment.Item()
+        }
+    }
+}
+
+private object PostDetailPreviewData {
+    val samplePostDetail = PostDetailUiModel(
+        id = "post_detail_1",
+        content = PostDetailContentUiModel(
+            category = PostDetailContentUiModel.CategoryUiModel(
+                text = RichTextType(
+                    text = "개발",
+                    color = ColorType.Token("primary300"),
+                    typography = "badge",
+                ),
+                target = "development",
+                icon = IconType(
+                    url = "https://cdn-icons-png.flaticon.com/128/3524/3524335.png",
+                    color = ColorType.Token("primary300"),
+                ),
+            ),
+            headerSection = PostDetailContentUiModel.HeaderSectionUiModel(
+                profileImage = "https://via.placeholder.com/48",
+                nickname = RichTextType(
+                    text = "김개발자",
+                    color = ColorType.Token("white"),
+                    typography = "body3",
+                ),
+                createdAt = RichTextType(
+                    text = "2024년 1월 15일 14:30",
+                    color = ColorType.Token("gray400"),
+                    typography = "body8",
+                ),
+                button = PostDetailContentUiModel.HeaderSectionUiModel.ButtonUiModel(
+                    type = "notification",
+                    icon = IconType(
+                        url = "https://cdn-icons-png.flaticon.com/128/3524/3524335.png",
+                        color = ColorType.Token("gray400"),
+                    ),
+                    text = RichTextType(
+                        text = "알림받기",
+                        color = ColorType.Token("gray400"),
+                        typography = "body7",
+                    ),
+                ),
+            ),
+            infoSection = PostDetailContentUiModel.InfoSectionUiModel(
+                title = RichTextType(
+                    text = "React 18의 새로운 Concurrent Features 완벽 가이드",
+                    color = ColorType.Token("white"),
+                    typography = "header3",
+                ),
+                description = RichTextType(
+                    text = "React 18에서 도입된 Concurrent Features는 사용자 경험을 크게 개선할 수 있는 강력한 기능들입니다. " +
+                        "이번 포스트에서는 Suspense, useTransition, useDeferredValue 등의 새로운 기능들을 실제 예제와 함께 자세히 살펴보겠습니다. " +
+                        "각 기능의 사용법부터 실무에서의 활용 방안까지 포괄적으로 다루어보겠습니다.",
+                    color = ColorType.Token("white"),
+                    typography = "body6",
+                ),
+                maxLine = 0,
+            ),
+            contentSection = PostDetailContentUiModel.ContentSectionUiModel.ImagesContentUiModel(
+                content = listOf(
+                    ImageType(
+                        url = "https://via.placeholder.com/320x200",
+                        width = 320,
+                        height = 200,
+                    ),
+                    ImageType(
+                        url = "https://via.placeholder.com/320x200",
+                        width = 320,
+                        height = 200,
+                    ),
+                ),
+            ),
+            footerSection = PostDetailContentUiModel.FooterSectionUiModel(
+                reactions = listOf(
+                    PostDetailContentUiModel.FooterSectionUiModel.ReactionUiModel.LikeUiModel(
+                        icon = IconType(
+                            url = "https://cdn-icons-png.flaticon.com/128/15407/15407695.png",
+                            color = ColorType.Token("gray300"),
+                        ),
+                        count = RichTextType(
+                            text = "24",
+                            color = ColorType.Token("gray300"),
+                            typography = "body6",
+                        ),
+                        selected = false,
+                    ),
+                    PostDetailContentUiModel.FooterSectionUiModel.ReactionUiModel.ChatUiModel(
+                        icon = IconType(
+                            url = "https://cdn-icons-png.flaticon.com/128/646/646094.png",
+                            color = ColorType.Token("gray300"),
+                        ),
+                        count = RichTextType(
+                            text = "8",
+                            color = ColorType.Token("gray300"),
+                            typography = "body6",
+                        ),
+                        selected = false,
+                    ),
+                ),
+                scrap = PostDetailContentUiModel.FooterSectionUiModel.ScrapUiModel(
+                    icon = IconType(
+                        url = "https://cdn-icons-png.flaticon.com/512/3031/3031121.png",
+                        color = ColorType.Token("gray300"),
+                    ),
+                    count = RichTextType(
+                        text = "12",
+                        color = ColorType.Token("gray300"),
+                        typography = "body6",
+                    ),
+                ),
+            ),
+        ),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PostDetailScreenPreview() {
+    WeSpotTheme {
+        PostDetailScreen(
+            uiModel = PostDetailPreviewData.samplePostDetail.content,
+            comments = emptyList(),
+        )
+    }
+}

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/screen/PostDetailScreen.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/screen/PostDetailScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -224,7 +223,7 @@ private fun PostDetailContentUiModel.HeaderSectionUiModel.Item(
                 .clip(RoundedCornerShape(8.dp))
                 .background(
                     WeSpotThemeManager.colors.cardBackgroundColor,
-                    RoundedCornerShape(8.dp)
+                    RoundedCornerShape(8.dp),
                 ),
         ) {
             Row(
@@ -489,8 +488,8 @@ private object PostDetailPreviewData {
                 ),
                 description = RichTextType(
                     text = "React 18에서 도입된 Concurrent Features는 사용자 경험을 크게 개선할 수 있는 강력한 기능들입니다. " +
-                            "이번 포스트에서는 Suspense, useTransition, useDeferredValue 등의 새로운 기능들을 실제 예제와 함께 자세히 살펴보겠습니다. " +
-                            "각 기능의 사용법부터 실무에서의 활용 방안까지 포괄적으로 다루어보겠습니다.",
+                        "이번 포스트에서는 Suspense, useTransition, useDeferredValue 등의 새로운 기능들을 실제 예제와 함께 자세히 살펴보겠습니다. " +
+                        "각 기능의 사용법부터 실무에서의 활용 방안까지 포괄적으로 다루어보겠습니다.",
                     color = ColorType.Token("white"),
                     typography = "body6",
                 ),

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/state/PostDetailAction.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/state/PostDetailAction.kt
@@ -1,0 +1,3 @@
+package com.bff.wespot.community.detail.state
+
+sealed interface PostDetailAction

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/state/PostDetailParams.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/state/PostDetailParams.kt
@@ -1,0 +1,5 @@
+package com.bff.wespot.community.detail.state
+
+data class PostDetailParams(
+    val postId: String,
+)

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/state/PostDetailSideEffect.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/state/PostDetailSideEffect.kt
@@ -1,0 +1,3 @@
+package com.bff.wespot.community.detail.state
+
+sealed interface PostDetailSideEffect

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/state/PostDetailUiState.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/detail/state/PostDetailUiState.kt
@@ -1,0 +1,9 @@
+package com.bff.wespot.community.detail.state
+
+import com.bff.wespot.community.uimodel.PostCommentUiModel
+import com.bff.wespot.community.uimodel.PostDetailUiModel
+
+data class PostDetailUiState(
+    val detail: PostDetailUiModel = PostDetailUiModel.Empty,
+    val comments: List<PostCommentUiModel> = emptyList(),
+)

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/di/PostDetailModule.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/di/PostDetailModule.kt
@@ -1,23 +1,23 @@
 package com.bff.wespot.community.di
 
-import android.content.Context
+import androidx.lifecycle.SavedStateHandle
 import com.bff.wespot.community.detail.state.PostDetailParams
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ActivityComponent
-import dagger.hilt.android.qualifiers.ActivityContext
+import dagger.hilt.android.components.ViewModelComponent
 
 @Module
-@InstallIn(ActivityComponent::class)
+@InstallIn(ViewModelComponent::class)
 object PostDetailModule {
     @Provides
     fun providePostDetailParams(
-        @ActivityContext context: Context,
+        savedStateHandle: SavedStateHandle,
     ): PostDetailParams {
-        val postId = context as android.app.Activity
+        val postId = savedStateHandle.get<String>("postId") ?: ""
+
         return PostDetailParams(
-            postId = postId.intent.getStringExtra("postId") ?: "",
+            postId = postId,
         )
     }
 }

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/di/PostDetailModule.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/di/PostDetailModule.kt
@@ -1,0 +1,23 @@
+package com.bff.wespot.community.di
+
+import android.content.Context
+import com.bff.wespot.community.detail.state.PostDetailParams
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.qualifiers.ActivityContext
+
+@Module
+@InstallIn(ActivityComponent::class)
+object PostDetailModule {
+    @Provides
+    fun providePostDetailParams(
+        @ActivityContext context: Context,
+    ): PostDetailParams {
+        val postId = context as android.app.Activity
+        return PostDetailParams(
+            postId = postId.intent.getStringExtra("postId") ?: "",
+        )
+    }
+}

--- a/feature/community/presentation/src/main/java/com/bff/wespot/community/screen/CommunityHomeScreen.kt
+++ b/feature/community/presentation/src/main/java/com/bff/wespot/community/screen/CommunityHomeScreen.kt
@@ -78,7 +78,14 @@ internal fun CommunityHomeScreen(
             ) { post ->
                 when (post) {
                     is PostItemUiModel -> {
-                        post.content.Item()
+                        post.content.Item(
+                            navigateToPost = {
+                                navigator.navigateToPostDetailActivity(
+                                    context = context,
+                                    postId = post.id,
+                                )
+                            },
+                        )
                     }
 
                     is BannerItemUiModel -> {

--- a/feature/community/presentation/src/main/res/drawable/horizontal_3dot.xml
+++ b/feature/community/presentation/src/main/res/drawable/horizontal_3dot.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M10,20m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#76777D"/>
+  <path
+      android:pathData="M20,20m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#76777D"/>
+  <path
+      android:pathData="M30,20m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#76777D"/>
+</vector>

--- a/feature/community/presentation/src/main/res/drawable/like.xml
+++ b/feature/community/presentation/src/main/res/drawable/like.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="15dp"
+    android:viewportWidth="14"
+    android:viewportHeight="15">
+  <path
+      android:pathData="M9.61,12.166H2.393C2.2,12.166 2.043,12.009 2.043,11.816V6.1C2.043,5.906 2.2,5.749 2.393,5.749H4.007C4.417,5.749 4.797,5.534 5.008,5.183L6.589,2.548C6.93,1.979 7.734,1.925 8.148,2.443C8.343,2.687 8.406,3.012 8.316,3.311L7.72,5.299C7.652,5.523 7.821,5.749 8.055,5.749H10.724C11.493,5.749 12.052,6.481 11.849,7.223L10.736,11.306C10.597,11.814 10.136,12.166 9.61,12.166Z"
+      android:strokeWidth="1.16667"
+      android:fillColor="#76777D"
+      android:strokeColor="#76777D"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/community/presentation/src/main/res/values/strings.xml
+++ b/feature/community/presentation/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="write_description_placeholder">어떤 생각을 하고 계신가요?\n학교 친구들과 함께 생각을 나눠보세요</string>
     <string name="write_category_detail_title">게시판 카테고리</string>
     <string name="write_select_category">카테고리 선택</string>
+    <string name="postdetail_report">신고</string>
+    <string name="postdetail_delete">삭제</string>
 </resources>

--- a/feature/community/ui-model/src/main/kotlin/com/bff/wespot/community/uimodel/PostCommentUiModel.kt
+++ b/feature/community/ui-model/src/main/kotlin/com/bff/wespot/community/uimodel/PostCommentUiModel.kt
@@ -1,0 +1,23 @@
+package com.bff.wespot.community.uimodel
+
+import com.bff.wespot.model.community.PostComment
+
+data class PostCommentUiModel(
+    val isMe: Boolean,
+    val nickname: String,
+    val profileImage: String,
+    val message: String,
+    val createdAt: String,
+    val likeCount: Int,
+) {
+    companion object {
+        fun PostComment.toUiModel() = PostCommentUiModel(
+            isMe = isMe,
+            nickname = nickname,
+            profileImage = profileImage,
+            message = message,
+            createdAt = createdAt,
+            likeCount = likeCount,
+        )
+    }
+}

--- a/feature/community/ui-model/src/main/kotlin/com/bff/wespot/community/uimodel/PostDetailUiModel.kt
+++ b/feature/community/ui-model/src/main/kotlin/com/bff/wespot/community/uimodel/PostDetailUiModel.kt
@@ -1,0 +1,227 @@
+package com.bff.wespot.community.uimodel
+
+import com.bff.wespot.model.community.PostDetail
+import com.bff.wespot.model.serverDriven.type.ColorType
+import com.bff.wespot.model.serverDriven.type.IconType
+import com.bff.wespot.model.serverDriven.type.ImageType
+import com.bff.wespot.model.serverDriven.type.RichTextType
+
+data class PostDetailUiModel(
+    val id: String,
+    val content: PostDetailContentUiModel,
+) {
+    data class PostDetailContentUiModel(
+        val category: CategoryUiModel,
+        val headerSection: HeaderSectionUiModel,
+        val infoSection: InfoSectionUiModel,
+        val contentSection: ContentSectionUiModel?,
+        val footerSection: FooterSectionUiModel,
+    ) {
+        data class CategoryUiModel(
+            val text: RichTextType,
+            val target: String,
+            val icon: IconType,
+        )
+
+        data class HeaderSectionUiModel(
+            val profileImage: String,
+            val nickname: RichTextType,
+            val createdAt: RichTextType,
+            val button: ButtonUiModel,
+        ) {
+            data class ButtonUiModel(
+                val type: String,
+                val icon: IconType,
+                val text: RichTextType,
+            )
+        }
+
+        data class InfoSectionUiModel(
+            val title: RichTextType,
+            val description: RichTextType,
+            val maxLine: Int,
+        )
+
+        sealed interface ContentSectionUiModel {
+            data class ImagesContentUiModel(
+                val content: List<ImageType>,
+            ) : ContentSectionUiModel
+        }
+
+        data class FooterSectionUiModel(
+            val reactions: List<ReactionUiModel>,
+            val scrap: ScrapUiModel,
+        ) {
+            sealed class ReactionUiModel(
+                open val icon: IconType,
+                open val count: RichTextType,
+                open val selected: Boolean,
+            ) {
+                data class ChatUiModel(
+                    override val icon: IconType,
+                    override val count: RichTextType,
+                    override val selected: Boolean,
+                ) : ReactionUiModel(icon, count, selected)
+
+                data class LikeUiModel(
+                    override val icon: IconType,
+                    override val count: RichTextType,
+                    override val selected: Boolean,
+                ) : ReactionUiModel(icon, count, selected)
+            }
+
+            data class ScrapUiModel(
+                val icon: IconType,
+                val count: RichTextType,
+            )
+        }
+    }
+
+    companion object {
+        fun PostDetail.toUiModel() = PostDetailUiModel(
+            id = id,
+            content = content.toUiModel(),
+        )
+
+        val Empty = PostDetailUiModel(
+            id = "",
+            content = PostDetailContentUiModel(
+                category = PostDetailContentUiModel.CategoryUiModel(
+                    text = RichTextType(
+                        text = "",
+                        color = ColorType.Token(""),
+                        typography = "",
+                    ),
+                    target = "",
+                    icon = IconType(url = "", color = ColorType.Token("")),
+                ),
+                headerSection = PostDetailContentUiModel.HeaderSectionUiModel(
+                    profileImage = "",
+                    nickname = RichTextType(
+                        text = "",
+                        color = ColorType.Token(""),
+                        typography = "",
+                    ),
+                    createdAt = RichTextType(
+                        text = "",
+                        color = ColorType.Token(""),
+                        typography = "",
+                    ),
+                    button = PostDetailContentUiModel.HeaderSectionUiModel.ButtonUiModel(
+                        type = "",
+                        icon = IconType(url = "", color = ColorType.Token("")),
+                        text = RichTextType(
+                            text = "",
+                            color = ColorType.Token(""),
+                            typography = "",
+                        ),
+                    ),
+                ),
+                infoSection = PostDetailContentUiModel.InfoSectionUiModel(
+                    title = RichTextType(
+                        text = "",
+                        color = ColorType.Token(""),
+                        typography = "",
+                    ),
+                    description = RichTextType(
+                        text = "",
+                        color = ColorType.Token(""),
+                        typography = "",
+                    ),
+                    maxLine = 0,
+                ),
+                contentSection = null,
+                footerSection = PostDetailContentUiModel.FooterSectionUiModel(
+                    reactions = emptyList(),
+                    scrap = PostDetailContentUiModel.FooterSectionUiModel.ScrapUiModel(
+                        icon = IconType(url = "", color = ColorType.Token("")),
+                        count = RichTextType(
+                            text = "",
+                            color = ColorType.Token(""),
+                            typography = "",
+                        ),
+                    ),
+                ),
+            ),
+        )
+    }
+}
+
+private fun PostDetail.PostDetailContent.toUiModel() = PostDetailUiModel.PostDetailContentUiModel(
+    category = category.toUiModel(),
+    headerSection = headerSection.toUiModel(),
+    infoSection = infoSection.toUiModel(),
+    contentSection = contentSection?.toUiModel(),
+    footerSection = footerSection.toUiModel(),
+)
+
+private fun PostDetail.PostDetailContent.Category.toUiModel() =
+    PostDetailUiModel.PostDetailContentUiModel.CategoryUiModel(
+        text = text,
+        target = target,
+        icon = icon,
+    )
+
+private fun PostDetail.PostDetailContent.HeaderSection.toUiModel() =
+    PostDetailUiModel.PostDetailContentUiModel.HeaderSectionUiModel(
+        profileImage = profileImage,
+        nickname = nickname,
+        createdAt = createdAt,
+        button = button.toUiModel(),
+    )
+
+private fun PostDetail.PostDetailContent.HeaderSection.Button.toUiModel() =
+    PostDetailUiModel.PostDetailContentUiModel.HeaderSectionUiModel.ButtonUiModel(
+        type = type,
+        icon = icon,
+        text = text,
+    )
+
+private fun PostDetail.PostDetailContent.InfoSection.toUiModel() =
+    PostDetailUiModel.PostDetailContentUiModel.InfoSectionUiModel(
+        title = title,
+        description = description,
+        maxLine = maxLine,
+    )
+
+private fun PostDetail.PostDetailContent.ContentSection.toUiModel(): PostDetailUiModel.PostDetailContentUiModel.ContentSectionUiModel =
+    when (this) {
+        is PostDetail.PostDetailContent.ContentSection.ImagesContent -> {
+            this.toUiModel()
+        }
+    }
+
+private fun PostDetail.PostDetailContent.ContentSection.ImagesContent.toUiModel() =
+    PostDetailUiModel.PostDetailContentUiModel.ContentSectionUiModel.ImagesContentUiModel(
+        content = content,
+    )
+
+private fun PostDetail.PostDetailContent.FooterSection.toUiModel() =
+    PostDetailUiModel.PostDetailContentUiModel.FooterSectionUiModel(
+        reactions = reactions.map { it.toUiModel() },
+        scrap = scrap.toUiModel(),
+    )
+
+private fun PostDetail.PostDetailContent.FooterSection.Reaction.toUiModel() = when (this) {
+    is PostDetail.PostDetailContent.FooterSection.Reaction.Chat -> {
+        PostDetailUiModel.PostDetailContentUiModel.FooterSectionUiModel.ReactionUiModel.ChatUiModel(
+            icon = icon,
+            count = count,
+            selected = selected,
+        )
+    }
+
+    is PostDetail.PostDetailContent.FooterSection.Reaction.Like -> {
+        PostDetailUiModel.PostDetailContentUiModel.FooterSectionUiModel.ReactionUiModel.LikeUiModel(
+            icon = icon,
+            count = count,
+            selected = selected,
+        )
+    }
+}
+
+private fun PostDetail.PostDetailContent.FooterSection.Scrap.toUiModel() =
+    PostDetailUiModel.PostDetailContentUiModel.FooterSectionUiModel.ScrapUiModel(
+        icon = icon,
+        count = count,
+    )

--- a/feature/community/ui-model/src/main/kotlin/com/bff/wespot/community/uimodel/PostDetailUiModel.kt
+++ b/feature/community/ui-model/src/main/kotlin/com/bff/wespot/community/uimodel/PostDetailUiModel.kt
@@ -184,7 +184,7 @@ private fun PostDetail.PostDetailContent.InfoSection.toUiModel() =
         maxLine = maxLine,
     )
 
-private fun PostDetail.PostDetailContent.ContentSection.toUiModel(): PostDetailUiModel.PostDetailContentUiModel.ContentSectionUiModel =
+private fun PostDetail.PostDetailContent.ContentSection.toUiModel() =
     when (this) {
         is PostDetail.PostDetailContent.ContentSection.ImagesContent -> {
             this.toUiModel()


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
close #272 

## 2. 🔥 변경된 점
게시글 상세 UI 추가

## 3. ✅ 필수 체크 사항 
나중에 서버 나오면 더 자세하게 작업 예정

## 4. 📸 작업물 사진 공유(선택)
<img width="583" height="1258" alt="스크린샷 2025-07-25 오후 8 34 35" src="https://github.com/user-attachments/assets/5f4ffc27-60fa-4003-8fae-596041630733" />

## 5. 💡알게된 혹은 궁금한 사항
